### PR TITLE
fix: OAuth2 로그인 요청에서 provider를 PathVariable로 처리 

### DIFF
--- a/src/main/java/com/project/Journey/login/oauth2/controller/OAuth2Controller.java
+++ b/src/main/java/com/project/Journey/login/oauth2/controller/OAuth2Controller.java
@@ -67,7 +67,7 @@ public class OAuth2Controller {
     @PostMapping("/{provider}")
     public ResponseEntity<?> socialLoginCallback(
             @Parameter(description = "소셜 로그인 제공자 (kakao 또는 naver)", example = "kakao")
-            @RequestParam String provider,
+            @PathVariable String provider,
 
             @Parameter(description = "프론트에서 받은 인가 코드", example = "abc123xyz456")
             @RequestParam String code,


### PR DESCRIPTION
📌 작업 내용

- 기존에 쿼리 파라미터로 받던 provider 값을 URL 경로에서 추출하도록 수정
- @RequestParam String provider → @PathVariable String provider로 변경
- 예시: /api/oauth2?provider=kakao&code=xxx → /api/oauth2/kakao?code=xxx로 사용 가능

🐛 해결한 문제

- 기존 방식에서는 provider 파라미터 누락으로 인해 500 에러 발생
- 오류 메시지: Required request parameter 'provider' for method parameter type String is not present

✅ 기대 효과

- 카카오 로그인 및 소셜 로그인 정상 동작
- 프론트엔드 요청 방식과 일치하게 맞춤