### PR TITLE
feat: 댓글 기능 개발 (#27)

### DIFF
--- a/src/main/java/com/project/Journey/board/comment/controller/CommentController.java
+++ b/src/main/java/com/project/Journey/board/comment/controller/CommentController.java
@@ -1,6 +1,7 @@
 package com.project.Journey.board.comment.controller;
 
 import com.project.Journey.board.comment.entity.Comment;
+import com.project.Journey.board.comment.entity.CommentResponseDTO;
 import com.project.Journey.board.comment.service.CommentService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -10,12 +11,14 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.Setter;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
-@Tag(name = "댓글", description = "댓글 및 대댓글(1단계) 관련 API")
+@Tag(name = "댓글", description = "댓글 및 대댓글(1단계) API")
 @RestController
 @RequestMapping("/api/posts")
 @RequiredArgsConstructor
@@ -23,102 +26,75 @@ public class CommentController {
 
     private final CommentService commentService;
 
-    @Getter
-    @Setter
+    @Getter @Setter
     static class CommentRequest {
-        @Schema(description = "댓글 작성자 식별자", example = "john123")
-        private String userId;
+        @Schema(description = "작성자 Member PK", example = "1")
+        private Long memberId;
 
-        @Schema(description = "댓글 또는 대댓글 내용", example = "안녕하세요!")
+        @Schema(description = "댓글 또는 대댓글 본문", example = "안녕하세요!")
         private String content;
 
-        @Schema(description = "부모 댓글 ID (없으면 최상위, 있으면 대댓글)")
+        @Schema(description = "부모 댓글 ID(대댓글일 때만)", nullable = true)
         private Long parentCommentId;
     }
 
-    @Operation(summary = "댓글 생성", description = "게시글에 댓글 또는 대댓글을 생성")
+    @Operation(summary = "댓글/대댓글 작성")
     @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "생성 성공"),
-            @ApiResponse(responseCode = "400", description = "잘못된 요청 혹은 존재하지 않는 게시글/부모 댓글")
+            @ApiResponse(responseCode = "201", description = "생성 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청")
     })
     @PostMapping("/{postId}/comments")
-    public ResponseEntity<?> createComment(
+    public ResponseEntity<CommentResponseDTO> createComment(
             @PathVariable Long postId,
-            @RequestBody CommentRequest request
-    ) {
-        try {
-            Comment comment = commentService.createComment(
-                    postId,
-                    request.getUserId(),
-                    request.getContent(),
-                    request.getParentCommentId()
-            );
-            return ResponseEntity.ok(comment.getCommentId());
-        } catch (IllegalArgumentException e) {
-            return ResponseEntity.badRequest().body(e.getMessage());
-        }
+            @RequestBody CommentRequest req) {
+
+        Comment saved = commentService.createComment(
+                postId, req.getMemberId(), req.getContent(), req.getParentCommentId());
+
+        return ResponseEntity
+                .status(HttpStatus.CREATED)
+                .body(CommentResponseDTO.from(saved));
     }
 
-    @Operation(summary = "댓글 목록 조회", description = "특정 게시글의 최상위 댓글 목록을 조회")
-    @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "조회 성공"),
-            @ApiResponse(responseCode = "400", description = "잘못된 요청 혹은 존재하지 않는 게시글")
-    })
+    @Operation(summary = "게시글 댓글 목록 조회")
     @GetMapping("/{postId}/comments")
-    public ResponseEntity<?> getComments(@PathVariable Long postId) {
-        try {
-            List<Comment> comments = commentService.getCommentsByPost(postId);
-            return ResponseEntity.ok(comments);
-        } catch (IllegalArgumentException e) {
-            return ResponseEntity.badRequest().body(e.getMessage());
-        }
+    public ResponseEntity<List<CommentResponseDTO>> getComments(@PathVariable Long postId) {
+
+        List<CommentResponseDTO> list = commentService.getCommentsByPost(postId)
+                .stream()
+                .map(CommentResponseDTO::from)
+                .collect(Collectors.toList());
+
+        return ResponseEntity.ok(list);
     }
 
-    @Operation(summary = "대댓글 목록 조회", description = "특정 댓글의 대댓글(1단) 목록을 조회")
-    @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "조회 성공"),
-            @ApiResponse(responseCode = "400", description = "잘못된 요청 혹은 존재하지 않는 댓글")
-    })
+    @Operation(summary = "대댓글 목록 조회")
     @GetMapping("/comments/{commentId}/replies")
-    public ResponseEntity<?> getReplies(@PathVariable Long commentId) {
-        try {
-            List<Comment> replies = commentService.getReplies(commentId);
-            return ResponseEntity.ok(replies);
-        } catch (IllegalArgumentException e) {
-            return ResponseEntity.badRequest().body(e.getMessage());
-        }
+    public ResponseEntity<List<CommentResponseDTO>> getReplies(@PathVariable Long commentId) {
+
+        List<CommentResponseDTO> list = commentService.getReplies(commentId)
+                .stream()
+                .map(CommentResponseDTO::from)
+                .collect(Collectors.toList());
+
+        return ResponseEntity.ok(list);
     }
 
-    @Operation(summary = "댓글 수정", description = "특정 댓글 또는 대댓글 내용을 수정")
-    @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "수정 성공"),
-            @ApiResponse(responseCode = "400", description = "잘못된 요청 혹은 존재하지 않는 댓글")
-    })
+    @Operation(summary = "댓글/대댓글 수정")
     @PatchMapping("/comments/{commentId}")
-    public ResponseEntity<?> updateComment(
+    public ResponseEntity<CommentResponseDTO> updateComment(
             @PathVariable Long commentId,
-            @RequestBody CommentRequest request
-    ) {
-        try {
-            Comment updated = commentService.updateComment(commentId, request.getContent());
-            return ResponseEntity.ok(updated.getCommentId());
-        } catch (IllegalArgumentException e) {
-            return ResponseEntity.badRequest().body(e.getMessage());
-        }
+            @RequestBody CommentRequest req) {
+
+        Comment updated = commentService.updateComment(commentId, req.getContent());
+        return ResponseEntity.ok(CommentResponseDTO.from(updated));
     }
 
-    @Operation(summary = "댓글 삭제", description = "특정 댓글 또는 대댓글을 삭제")
-    @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "삭제 성공"),
-            @ApiResponse(responseCode = "400", description = "잘못된 요청 혹은 존재하지 않는 댓글")
-    })
+    @Operation(summary = "댓글/대댓글 삭제")
     @DeleteMapping("/comments/{commentId}")
-    public ResponseEntity<?> deleteComment(@PathVariable Long commentId) {
-        try {
-            commentService.deleteComment(commentId);
-            return ResponseEntity.ok("삭제 완료");
-        } catch (IllegalArgumentException e) {
-            return ResponseEntity.badRequest().body(e.getMessage());
-        }
+    public ResponseEntity<Void> deleteComment(@PathVariable Long commentId) {
+
+        commentService.deleteComment(commentId);
+        return ResponseEntity.noContent().build();   // 204 No-Content
     }
 }

--- a/src/main/java/com/project/Journey/board/comment/entity/Comment.java
+++ b/src/main/java/com/project/Journey/board/comment/entity/Comment.java
@@ -1,6 +1,7 @@
 package com.project.Journey.board.comment.entity;
 
 import com.project.Journey.board.entity.Post;
+import com.project.Journey.login.member.domain.Member;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -22,8 +23,9 @@ public class Comment {
     @JoinColumn(name = "post_id")
     private Post post;
 
-    @Column(name = "user_id", nullable = false, length = 100)
-    private String userId;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
 
     @Column(nullable = false, columnDefinition = "TEXT")
     private String content;
@@ -34,6 +36,30 @@ public class Comment {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "parent_comment_id")
     private Comment parentComment;
+
+    @Column(nullable = false)
+    @Builder.Default
+    private boolean isActive = true;      // true = 노출, false = 삭제
+
+    @Builder.Default
+    @Column(nullable = false)
+    private int replyCount = 0;             // 자식 대댓글 수
+
+    public void setContent(String content) {
+        this.content = content;
+    }
+    public void deactivate() {
+        this.isActive = false;
+    }
+    public void incrementReplyCount() {
+        this.replyCount++;
+    }
+    public void decrementReplyCount() {
+        if (this.replyCount > 0) this.replyCount--;
+    }
+    public boolean isActive() {
+        return isActive;
+    }
 
     @PrePersist
     public void onPrePersist() {

--- a/src/main/java/com/project/Journey/board/comment/entity/CommentDTO.java
+++ b/src/main/java/com/project/Journey/board/comment/entity/CommentDTO.java
@@ -18,7 +18,7 @@ import java.util.List;
 public class CommentDTO {
 
     private Long commentId;
-    private String userId;
+    private Long memberId;
 
     @NotBlank
     private String content;

--- a/src/main/java/com/project/Journey/board/comment/entity/CommentResponseDTO.java
+++ b/src/main/java/com/project/Journey/board/comment/entity/CommentResponseDTO.java
@@ -1,0 +1,40 @@
+package com.project.Journey.board.comment.entity;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter @Builder
+public class CommentResponseDTO {
+
+    private Long commentId;
+    private Long postId;
+    private Long memberId;
+    private String displayName;
+    private String profileImage;
+    private String content;
+    private Long parentCommentId;
+    private int  replyCount;
+    private boolean isActive;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+
+    public static CommentResponseDTO from(Comment c) {
+        return CommentResponseDTO.builder()
+                .commentId(c.getCommentId())
+                .postId(c.getPost().getPostId())
+                .memberId(c.getMember().getId())
+                .displayName(c.getMember().getDisplayName())
+                .profileImage(c.getMember().getProfileImage())
+                .content(c.getContent())
+                .parentCommentId(
+                        c.getParentComment() != null ? c.getParentComment().getCommentId() : null)
+                .replyCount(c.getReplyCount())
+                .isActive(c.isActive())
+                .createdAt(c.getCreatedAt())
+                .updatedAt(c.getUpdatedAt())
+                .build();
+    }
+}
+

--- a/src/main/java/com/project/Journey/board/comment/repository/CommentRepository.java
+++ b/src/main/java/com/project/Journey/board/comment/repository/CommentRepository.java
@@ -8,7 +8,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.List;
 
 public interface CommentRepository extends JpaRepository<Comment, Long> {
-
-    List<Comment> findByPostAndParentCommentIsNullOrderByCreatedAtAsc(Post post);
-    List<Comment> findByParentCommentOrderByCreatedAtAsc(Comment parent);
+    List<Comment> findByPostAndParentCommentIsNullAndIsActiveTrueOrderByCreatedAtAsc(Post post);
+    List<Comment> findByParentCommentAndIsActiveTrueOrderByCreatedAtAsc(Comment parent);
 }

--- a/src/main/java/com/project/Journey/board/comment/service/CommentService.java
+++ b/src/main/java/com/project/Journey/board/comment/service/CommentService.java
@@ -7,6 +7,9 @@ import com.project.Journey.board.comment.repository.CommentRepository;
 import com.project.Journey.board.entity.Post;
 
 import com.project.Journey.board.repository.PostRepository;
+import com.project.Journey.login.member.domain.Member;
+import com.project.Journey.login.member.repository.MemberRepository;
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -14,24 +17,35 @@ import java.util.List;
 
 @Service
 @RequiredArgsConstructor
+@Transactional
 public class CommentService {
 
     private final CommentRepository commentRepository;
     private final PostRepository postRepository;
+    private final MemberRepository memberRepository;
 
-    public Comment createComment(Long postId, String userId, String content, Long parentCommentId) {
+    public Comment createComment(Long postId, Long memberId,
+                                 String content, Long parentCommentId) {
+
         Post post = postRepository.findById(postId)
                 .orElseThrow(() -> new IllegalArgumentException("게시글이 존재하지 않습니다: " + postId));
 
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new IllegalArgumentException("회원이 존재하지 않습니다: " + memberId));
+
+        /* 부모 댓글 검증 / replyCount 증감 로직은 그대로 */
         Comment parent = null;
         if (parentCommentId != null) {
             parent = commentRepository.findById(parentCommentId)
                     .orElseThrow(() -> new IllegalArgumentException("부모 댓글이 존재하지 않습니다: " + parentCommentId));
+            if (parent.getParentComment() != null)
+                throw new IllegalArgumentException("대댓글은 한 단계만 허용됩니다");
+            parent.incrementReplyCount();
         }
 
         Comment comment = Comment.builder()
                 .post(post)
-                .userId(userId)
+                .member(member)          // ⭐ FK 세팅
                 .content(content)
                 .parentComment(parent)
                 .build();
@@ -39,32 +53,47 @@ public class CommentService {
         return commentRepository.save(comment);
     }
 
+    /* ---------- 댓글 목록 ---------- */
     public List<Comment> getCommentsByPost(Long postId) {
         Post post = postRepository.findById(postId)
                 .orElseThrow(() -> new IllegalArgumentException("게시글이 존재하지 않습니다: " + postId));
 
-        List<Comment> rootComments = commentRepository.findByPostAndParentCommentIsNullOrderByCreatedAtAsc(post);
-        return rootComments;
+        return commentRepository
+                .findByPostAndParentCommentIsNullAndIsActiveTrueOrderByCreatedAtAsc(post);
     }
 
     public List<Comment> getReplies(Long parentCommentId) {
         Comment parent = commentRepository.findById(parentCommentId)
                 .orElseThrow(() -> new IllegalArgumentException("댓글이 존재하지 않습니다: " + parentCommentId));
 
-        return commentRepository.findByParentCommentOrderByCreatedAtAsc(parent);
+        return commentRepository
+                .findByParentCommentAndIsActiveTrueOrderByCreatedAtAsc(parent);
     }
 
+    /* ---------- 댓글 수정 ---------- */
     public Comment updateComment(Long commentId, String content) {
         Comment comment = commentRepository.findById(commentId)
                 .orElseThrow(() -> new IllegalArgumentException("댓글이 존재하지 않습니다: " + commentId));
+
+        if (!comment.isActive()) {
+            throw new IllegalStateException("삭제된 댓글은 수정할 수 없습니다");
+        }
         comment.setContent(content);
-        return commentRepository.save(comment);
+        return comment;
     }
 
+    /* ---------- 논리 삭제 ---------- */
     public void deleteComment(Long commentId) {
-        // 대댓글이 있는 경우 어떻게 처리할지 결정 필요 (함께 삭제 vs 불가)
+
         Comment comment = commentRepository.findById(commentId)
                 .orElseThrow(() -> new IllegalArgumentException("댓글이 존재하지 않습니다: " + commentId));
-        commentRepository.delete(comment);
+
+        if (!comment.isActive()) return;          // 이미 삭제된 경우 무시
+
+        comment.deactivate();                     // 물리 삭제 대신 플래그만 변경
+
+        if (comment.getParentComment() != null) {
+            comment.getParentComment().decrementReplyCount();
+        }
     }
 }

--- a/src/main/java/com/project/Journey/community/comment/controller/CommunityCommentController.java
+++ b/src/main/java/com/project/Journey/community/comment/controller/CommunityCommentController.java
@@ -1,0 +1,91 @@
+package com.project.Journey.community.comment.controller;
+
+
+import com.project.Journey.community.comment.dto.CommunityCommentDTO;
+import com.project.Journey.community.comment.dto.CommunityCommentRequest;
+import com.project.Journey.community.comment.dto.CommunityCommentResponseDTO;
+import com.project.Journey.community.comment.entity.CommunityComment;
+import com.project.Journey.community.comment.service.CommunityCommentService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@Tag(name = "커뮤니티 댓글", description = "커뮤니티 게시판 댓글 · 대댓글(1단) API")
+@RestController
+@RequestMapping("/api/community")
+@RequiredArgsConstructor
+public class CommunityCommentController {
+
+    private final CommunityCommentService commentService;
+
+    @Operation(summary = "댓글/대댓글 작성",
+            description = "parentCommentId 가 null 이면 최상위 댓글, 값이 있으면 해당 댓글의 대댓글로 저장")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "생성 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청(게시글/부모 댓글 없음 등)")
+    })
+    @PostMapping("/{communityId}/comments")
+    public ResponseEntity<CommunityCommentResponseDTO> create(
+            @PathVariable Long communityId,
+            @RequestBody  CommunityCommentRequest req) {
+
+        CommunityCommentResponseDTO dto = commentService.createComment(communityId, req);
+        return ResponseEntity.status(HttpStatus.CREATED).body(dto);
+    }
+
+
+    @Operation(summary = "댓글 목록 조회",
+            description = "특정 커뮤니티 게시글의 최상위 댓글 + 대댓글(1단)을 함께 반환")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "400", description = "게시글 없음")
+    })
+    @GetMapping("/{communityId}/comments")
+    public ResponseEntity<List<CommunityCommentResponseDTO>> getComments(
+            @PathVariable Long communityId) {
+
+        return ResponseEntity.ok(commentService.getRootComments(communityId));
+    }
+
+    @Getter @Setter
+    static class UpdateRequest {
+        @Schema(description = "수정할 내용", example = "댓글을 수정합니다")
+        private String content;
+    }
+
+    @Operation(summary = "댓글 수정", description = "commentId 로 특정 댓글 내용을 수정")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "수정 성공"),
+            @ApiResponse(responseCode = "400", description = "댓글 없음")
+    })
+    @PatchMapping("/comments/{commentId}")
+    public ResponseEntity<CommunityCommentResponseDTO> update(
+            @PathVariable Long commentId,
+            @RequestBody  UpdateRequest req) {
+
+        CommunityCommentResponseDTO dto = commentService.updateComment(commentId, req.getContent());
+        return ResponseEntity.ok(dto);
+    }
+
+    @Operation(summary = "댓글 삭제", description = "commentId 로 댓글을 논리 삭제(isActive=false)")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "삭제 성공"),
+            @ApiResponse(responseCode = "400", description = "댓글 없음")
+    })
+    @DeleteMapping("/comments/{commentId}")
+    public ResponseEntity<String> delete(@PathVariable Long commentId) {
+
+        commentService.deleteComment(commentId);
+        return ResponseEntity.ok("삭제 완료");
+    }
+}

--- a/src/main/java/com/project/Journey/community/comment/dto/CommunityCommentDTO.java
+++ b/src/main/java/com/project/Journey/community/comment/dto/CommunityCommentDTO.java
@@ -1,0 +1,41 @@
+package com.project.Journey.community.comment.dto;
+
+import com.project.Journey.community.comment.entity.CommunityComment;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@Setter
+@Schema(description = "커뮤니티 댓글 응답 DTO (대댓글 포함)")
+public class CommunityCommentDTO {
+
+    @Schema(description = "댓글 PK")
+    private Long commentId;
+
+    @Schema(description = "작성자 ID")
+    private String userId;
+
+    @Schema(description = "내용")
+    private String content;
+
+    @Schema(description = "작성 시각")
+    private LocalDateTime createdAt;
+
+    @Schema(description = "대댓글 목록(1단)", nullable = true)
+    private List<CommunityCommentDTO> replies;
+
+    public CommunityCommentDTO(Long id, String userId, String content,
+                               LocalDateTime createdAt, List<CommunityCommentDTO> replies) {
+        this.commentId  = id;
+        this.userId     = userId;
+        this.content    = content;
+        this.createdAt  = createdAt;
+        this.replies    = replies;
+    }
+
+
+}

--- a/src/main/java/com/project/Journey/community/comment/dto/CommunityCommentRequest.java
+++ b/src/main/java/com/project/Journey/community/comment/dto/CommunityCommentRequest.java
@@ -1,0 +1,20 @@
+package com.project.Journey.community.comment.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Schema(description = "커뮤니티 댓글 작성/수정 요청 DTO")
+public class CommunityCommentRequest {
+
+    @Schema(description = "작성자 ID", example = "kaylee77")
+    private Long memberId;
+
+    @Schema(description = "내용",     example = "좋은 글이네요!")
+    private String content;
+
+    @Schema(description = "부모 댓글 ID (null ➜ 최상위)", example = "15")
+    private Long parentCommentId;
+}

--- a/src/main/java/com/project/Journey/community/comment/dto/CommunityCommentResponseDTO.java
+++ b/src/main/java/com/project/Journey/community/comment/dto/CommunityCommentResponseDTO.java
@@ -1,0 +1,56 @@
+package com.project.Journey.community.comment.dto;
+
+import com.project.Journey.community.comment.entity.CommunityComment;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+@Builder(toBuilder = true)
+public class CommunityCommentResponseDTO {
+
+    private Long commentId;
+    private Long communityId;
+    private Long memberId;
+    private String displayName;
+    private String profileImage;
+    private String content;
+    private Long parentCommentId;
+    private int  replyCount;
+    private boolean isActive;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+
+    public static CommunityCommentResponseDTO from(CommunityComment c) {
+        return CommunityCommentResponseDTO.builder()
+                .commentId(c.getCommentId())
+                .communityId(c.getCommunity().getCommunityPostId())
+                .memberId(c.getMember().getId())
+                .displayName(c.getMember().getDisplayName())
+                .profileImage(c.getMember().getProfileImage())
+                .content(c.getContent())
+                .parentCommentId(
+                        c.getParentComment() != null ? c.getParentComment().getCommentId() : null)
+                .replyCount(c.getReplyCount())
+                .isActive(c.isActive())
+                .createdAt(c.getCreatedAt())
+                .updatedAt(c.getUpdatedAt())
+                .build();
+    }
+
+    public static CommunityCommentResponseDTO withReplies(CommunityComment root,
+                                                          List<CommunityComment> replies) {
+        return CommunityCommentResponseDTO.from(root).toBuilder()
+                .replyCount(replies.size())
+                .build();
+    }
+
+    /* 유틸: List<CommunityComment> → List<DTO> */
+    public static List<CommunityCommentResponseDTO> listOf(List<CommunityComment> list) {
+        return list.stream().map(CommunityCommentResponseDTO::from).collect(Collectors.toList());
+    }
+}
+

--- a/src/main/java/com/project/Journey/community/comment/entity/CommunityComment.java
+++ b/src/main/java/com/project/Journey/community/comment/entity/CommunityComment.java
@@ -1,0 +1,64 @@
+package com.project.Journey.community.comment.entity;
+
+import com.project.Journey.community.entity.Community;
+import com.project.Journey.login.member.domain.Member;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "community_comment")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
+@AllArgsConstructor
+public class CommunityComment {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long commentId;
+
+    @ManyToOne(fetch = FetchType.LAZY)                       // ★ 작성자
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @ManyToOne(fetch = FetchType.LAZY)                       // ★ 게시글
+    @JoinColumn(name = "community_post_id", nullable = false)
+    private Community community;
+
+    @ManyToOne(fetch = FetchType.LAZY)                       // ★ 대댓글(1단)
+    @JoinColumn(name = "parent_comment_id")
+    private CommunityComment parentComment;
+
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String content;
+
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+
+    @Builder.Default                                          // 기본값 true
+    @Column(nullable = false)
+    private boolean isActive = true;
+
+    @Builder.Default
+    @Column(nullable = false)
+    private int replyCount = 0;
+
+    public void updateContent(String content)      { this.content = content; }
+    public void incrementReplyCount()              { this.replyCount++; }
+    public void decrementReplyCount()              { if (this.replyCount > 0) this.replyCount--; }
+    public void deactivate()                       { this.isActive = false; }
+
+    @PrePersist
+    public void onCreate() {
+        this.createdAt  = LocalDateTime.now();
+        this.updatedAt  = this.createdAt;
+    }
+    @PreUpdate
+    public void onUpdate()  { this.updatedAt = LocalDateTime.now(); }
+
+    @Transient
+    public Long getMemberId() {                       // 필요하면 DTO 변환 시 사용
+        return member != null ? member.getId() : null;
+    }
+}

--- a/src/main/java/com/project/Journey/community/comment/repository/CommunityCommentRepository.java
+++ b/src/main/java/com/project/Journey/community/comment/repository/CommunityCommentRepository.java
@@ -1,0 +1,12 @@
+package com.project.Journey.community.comment.repository;
+
+import com.project.Journey.community.comment.entity.CommunityComment;
+import com.project.Journey.community.entity.Community;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface CommunityCommentRepository extends JpaRepository<CommunityComment, Long> {
+    List<CommunityComment> findByCommunityAndParentCommentIsNullAndIsActiveTrueOrderByCreatedAtAsc(Community community);
+    List<CommunityComment> findByParentCommentAndIsActiveTrueOrderByCreatedAtAsc(CommunityComment parent);
+}

--- a/src/main/java/com/project/Journey/community/comment/service/CommunityCommentService.java
+++ b/src/main/java/com/project/Journey/community/comment/service/CommunityCommentService.java
@@ -1,0 +1,100 @@
+package com.project.Journey.community.comment.service;
+
+import com.project.Journey.community.comment.dto.CommunityCommentDTO;
+import com.project.Journey.community.comment.dto.CommunityCommentRequest;
+import com.project.Journey.community.comment.dto.CommunityCommentResponseDTO;
+import com.project.Journey.community.comment.entity.CommunityComment;
+import com.project.Journey.community.comment.repository.CommunityCommentRepository;
+import com.project.Journey.community.entity.Community;
+import com.project.Journey.community.repository.CommunityRepository;
+import com.project.Journey.login.member.domain.Member;
+import com.project.Journey.login.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class CommunityCommentService {
+
+    private final CommunityCommentRepository commentRepo;
+    private final CommunityRepository        communityRepo;
+    private final MemberRepository           memberRepo;
+
+    public CommunityCommentResponseDTO createComment(Long communityId,
+                                                     CommunityCommentRequest req) {
+
+        Community community = communityRepo.findById(communityId)
+                .orElseThrow(() -> new IllegalArgumentException("커뮤니티 글이 없습니다"));
+        Member member = memberRepo.findById(req.getMemberId())
+                .orElseThrow(() -> new IllegalArgumentException("회원이 없습니다"));
+
+        CommunityComment parent = null;
+        if (req.getParentCommentId() != null) {
+            parent = commentRepo.findById(req.getParentCommentId())
+                    .orElseThrow(() -> new IllegalArgumentException("부모 댓글이 없습니다"));
+            if (parent.getParentComment() != null)
+                throw new IllegalArgumentException("대댓글은 한 단계만 허용됩니다");
+            parent.incrementReplyCount();
+        }
+
+        CommunityComment saved = commentRepo.save(
+                CommunityComment.builder()
+                        .community(community)
+                        .member(member)
+                        .content(req.getContent())
+                        .parentComment(parent)
+                        .build());
+
+        return CommunityCommentResponseDTO.from(saved);
+    }
+
+    @Transactional(readOnly = true)
+    public List<CommunityCommentResponseDTO> getRootComments(Long communityId) {
+
+        Community community = communityRepo.findById(communityId)
+                .orElseThrow(() -> new IllegalArgumentException("커뮤니티 글이 없습니다"));
+
+        return commentRepo
+                .findByCommunityAndParentCommentIsNullAndIsActiveTrueOrderByCreatedAtAsc(community)
+                .stream()
+                .map(CommunityCommentResponseDTO::from)
+                .collect(Collectors.toList());
+    }
+
+    @Transactional(readOnly = true)
+    public List<CommunityCommentResponseDTO> getReplies(Long parentId) {
+        CommunityComment parent = commentRepo.findById(parentId)
+                .orElseThrow(() -> new IllegalArgumentException("댓글이 없습니다"));
+
+        return commentRepo
+                .findByParentCommentAndIsActiveTrueOrderByCreatedAtAsc(parent)
+                .stream()
+                .map(CommunityCommentResponseDTO::from)
+                .collect(Collectors.toList());
+    }
+
+    public CommunityCommentResponseDTO updateComment(Long id, String content) {
+        CommunityComment c = commentRepo.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("댓글이 없습니다"));
+        if (!c.isActive())
+            throw new IllegalStateException("삭제된 댓글은 수정 불가");
+
+        c.updateContent(content);
+        return CommunityCommentResponseDTO.from(c);
+    }
+
+    public void deleteComment(Long id) {
+        CommunityComment c = commentRepo.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("댓글이 없습니다"));
+
+        if (!c.isActive()) return;           // 이미 삭제
+        c.deactivate();
+
+        if (c.getParentComment() != null)
+            c.getParentComment().decrementReplyCount();
+    }
+}

--- a/src/main/java/com/project/Journey/community/controller/CommunityController.java
+++ b/src/main/java/com/project/Journey/community/controller/CommunityController.java
@@ -54,6 +54,7 @@ public class CommunityController {
 
             return ResponseEntity.ok(savedPostId);
         } catch (Exception e){
+            log.error("게시글 저장 중 오류", e);
             throw new PostException("게시글 저장 중 오류가 발생했습니다.", HttpStatus.BAD_REQUEST);
         }
 

--- a/src/main/java/com/project/Journey/config/SwaggerConfig.java
+++ b/src/main/java/com/project/Journey/config/SwaggerConfig.java
@@ -11,25 +11,14 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 public class SwaggerConfig {
 
-    /**
-     * Swagger/OpenAPI 설정
-     */
     @Bean
     public OpenAPI openAPI() {
         return new OpenAPI()
                 .info(new Info()
-                        .title("Journey Login API")
-                        .description("소셜 로그인 + JWT + 회원가입 관련 API 문서")
-                        .version("v2.6.0")
-                        .contact(new Contact()
-                                .name("Journey Dev Team")
-                                .email("sprauncy76@gmail.com"))
-                )
-                .components(new Components()
-                        .addSecuritySchemes("BearerAuth",
-                                new SecurityScheme()
-                                        .type(SecurityScheme.Type.HTTP)
-                                        .scheme("bearer")
-                                        .bearerFormat("JWT")));
+                        .title("Journey API Documentation")
+                        .description("여정(Journey) 프로젝트의 전체 API 문서입니다. 로그인, 회원가입, 게시판 등 기능 포함.")
+                        .version("v1.0.0")
+                        .contact(new Contact().name("Journey Dev Team").email("sprauncy76@gmail.com"))
+                );
     }
 }


### PR DESCRIPTION
### 🔥 커뮤니티 & 게시글 댓글 기능 추가 (1-depth 대댓글 지원)

- Comment Entity 분리해서 구축 (커뮤니티/게시글 다른 로직 사용)
- 댓글/대댓글 등록, 조회, 수정, 삭제 API 구현
- soft delete 방식 적용 (isActive)
-> db에서는 삭제하지 않음.
- 대댓글 replyCount 증가/감소 처리

🔜 TODO
- 댓글 무한스크롤 대응
- 멘션 알림 연동
- 신고 및 관리자 숨김 처리


closes #27