### PR TITLE
feat: 서버 에러 알림 디스코드 전송 기능 구현 (#35)

### DIFF
--- a/src/main/java/com/project/Journey/common/DiscordLogNotifier.java
+++ b/src/main/java/com/project/Journey/common/DiscordLogNotifier.java
@@ -1,0 +1,44 @@
+package com.project.Journey.common;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.*;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+@Component
+public class DiscordLogNotifier {
+
+    private final RestTemplate restTemplate = new RestTemplate();
+
+    @Value("${discord.webhook-url}")
+    private String webhookUrl;
+
+    public void sendLog(String message) {
+        sendLog(message, false);
+    }
+
+    public void sendLog(String message, boolean isError) {
+        if (webhookUrl == null || webhookUrl.isBlank()) {
+            System.out.println("⚠️ Webhook URL이 설정되어 있지 않습니다.");
+            return;
+        }
+
+        // 디스코드 메시지 최대 길이 제한: 2000자
+        if (message.length() > 1900) {
+            message = message.substring(0, 1900) + "...(중략)";
+        }
+
+        String emoji = isError ? "❌" : "✅";
+        String payload = String.format("{\"content\": \"%s %s\"}", emoji, message);
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        HttpEntity<String> request = new HttpEntity<>(payload, headers);
+
+        try {
+            restTemplate.postForEntity(webhookUrl, request, String.class);
+        } catch (Exception e) {
+            System.out.println("❌ 디스코드 전송 실패: " + e.getMessage());
+        }
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,5 +1,5 @@
-# MySQL ??
-spring.datasource.url=jdbc:mysql://mydb.cdmkas62q1dg.ap-northeast-2.rds.amazonaws.com:3306/mydb
+# MySQL
+spring.datasource.url=${SPRING_DATASOURCE_URL}
 spring.datasource.username=${SPRING_DATASOURCE_USERNAME}
 spring.datasource.password=${SPRING_DATASOURCE_PASSWORD}
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
@@ -8,21 +8,18 @@ spring.jpa.show-sql=true
 spring.jpa.database-platform=org.hibernate.dialect.MySQLDialect
 
 
-# Redis ??
-# spring.redis.host=127.0.0.1
-# spring.redis.port=6379
+# Redis
 spring.redis.host=127.0.0.1
 spring.redis.port=6379
 
-# OAuth2 ?? (application-XXX.properties ??)
+# OAuth2
 spring.profiles.include=oauth2
 
-# Thymeleaf ??
+# Thymeleaf
 spring.thymeleaf.cache=false
 spring.thymeleaf.prefix=classpath:/templates/
 spring.thymeleaf.suffix=.html
 
-# ?? ??? ??
 logging.level.org.springframework.security=DEBUG
 
 # swagger-ui custom path
@@ -36,7 +33,6 @@ spring.http.encoding.force=true
 spring.servlet.encoding.force=true
 spring.servlet.encoding.charset=UTF-8
 
-# ========== ?? ???? & ?? ?? ==========
 server.servlet.session.timeout=30m
 server.servlet.session.cookie.secure=true
 server.servlet.session.cookie.http-only=true
@@ -49,3 +45,6 @@ aws.region=${AWS_REGION}
 aws.bucket=${AWS_S3_BUCKET}
 aws.access-key=${AWS_ACCESS_KEY}
 aws.secret-key=${AWS_SECRET_KEY}
+
+# discord-서버에러알림
+discord.webhook-url=${DISCORD_WEBHOOK_URL}


### PR DESCRIPTION
📦 feat: 서버 에러 발생 시 디스코드로 알림 전송 기능 구현

- Discord Webhook URL을 통해 서버 오류 메시지를 실시간 전송하는 기능 추가
- `DiscordLogNotifier` 컴포넌트 구현
  - 일반 로그: ✅
  - 에러 로그: ❌ 이모지 포함
- Webhook URL 미설정 시 경고 출력
- 테스트용 RuntimeException 유발 코드로 Discord 전송 확인 완료

✅ 서버 모니터링 및 디버깅 효율 향상 기대


closes #35
