### PR TITLE
Profile & TravelPlan 기능 통합

### DIFF
--- a/src/main/java/com/project/Journey/login/member/controller/ProfileController.java
+++ b/src/main/java/com/project/Journey/login/member/controller/ProfileController.java
@@ -1,0 +1,87 @@
+package com.project.Journey.login.member.controller;
+
+import com.project.Journey.login.member.dto.ProfileResponse;
+import com.project.Journey.login.member.dto.ProfileUpdateRequest;
+import com.project.Journey.login.member.dto.TravelPlanRequest;
+import com.project.Journey.login.member.dto.TravelPlanResponse;
+import com.project.Journey.login.member.service.ProfileService;
+import com.project.Journey.login.member.service.TravelPlanService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@Tag(name = "프로필 및 여행일정", description = "프로필·여행일정 관리 API")
+@RestController
+@RequestMapping("/api/members")
+@RequiredArgsConstructor
+public class ProfileController {
+
+    private final ProfileService profileService;
+    private final TravelPlanService planService;
+
+    @Operation(summary = "내 프로필 조회")
+    @ApiResponse(responseCode = "200", description = "조회 성공",
+            content = @Content(schema = @Schema(implementation = ProfileResponse.class)))
+    @GetMapping("/{id}/profile")
+    public ProfileResponse getProfile(@PathVariable Long id) {
+        return profileService.getMyProfile(id);
+    }
+
+    @Operation(summary = "내 프로필 수정",
+            description = """
+               전달한 필드만 업데이트합니다.  
+               · tags : 최대 3개, 각 6자 ≤  
+               """)
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "수정 완료"),
+            @ApiResponse(responseCode = "400", description = "검증 실패 (태그 3개 초과, 6자 초과 등)")
+    })
+    @PatchMapping("/{id}/profile")
+    public ResponseEntity<?> updateProfile(@PathVariable Long id,
+                                           @Valid @RequestBody ProfileUpdateRequest dto) {
+        profileService.updateProfile(id, dto);
+        return ResponseEntity.ok("프로필 수정 완료");
+    }
+
+    @Operation(summary = "여행 일정 추가")
+    @ApiResponse(responseCode = "200", description = "등록 성공",
+            content = @Content(schema = @Schema(implementation = TravelPlanResponse.class)))
+    @PostMapping("/{id}/plans")
+    public TravelPlanResponse addPlan(@PathVariable Long id,
+                                      @RequestBody TravelPlanRequest req) {
+        return planService.addPlan(id, req);
+    }
+
+    @Operation(summary = "여행 일정 목록")
+    @ApiResponse(responseCode = "200", description = "조회 성공")
+    @GetMapping("/{id}/plans")
+    public List<TravelPlanResponse> listPlans(@PathVariable Long id) {
+        return planService.listPlans(id);
+    }
+
+    @Operation(summary = "여행 일정 수정")
+    @ApiResponse(responseCode = "200", description = "수정 성공")
+    @PatchMapping("/plans/{planId}")
+    public TravelPlanResponse updatePlan(@PathVariable Long planId,
+                                         @RequestBody TravelPlanRequest req) {
+        return planService.updatePlan(planId, req);
+    }
+
+    @Operation(summary = "여행 일정 삭제")
+    @ApiResponse(responseCode = "200", description = "삭제 성공")
+    @DeleteMapping("/plans/{planId}")
+    public ResponseEntity<?> deletePlan(@PathVariable Long planId) {
+        planService.deletePlan(planId);
+        return ResponseEntity.ok("삭제 완료");
+    }
+
+}

--- a/src/main/java/com/project/Journey/login/member/domain/Gender.java
+++ b/src/main/java/com/project/Journey/login/member/domain/Gender.java
@@ -1,0 +1,5 @@
+package com.project.Journey.login.member.domain;
+
+public enum Gender {
+    MALE, FEMALE
+}

--- a/src/main/java/com/project/Journey/login/member/domain/Member.java
+++ b/src/main/java/com/project/Journey/login/member/domain/Member.java
@@ -4,8 +4,11 @@ import jakarta.persistence.*;
 import lombok.*;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
+import java.util.ArrayList;
+import java.util.List;
+
 @Entity
-@Getter  // or @Getter @Setter(AccessLevel.PROTECTED) if you want
+@Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Member {
 
@@ -25,6 +28,22 @@ public class Member {
     private SocialType socialType;
     private String socialId;
     private String profileImage;
+
+    // Profile 관련 필드
+    private Integer age;
+    @Enumerated(EnumType.STRING)
+    private Gender gender;
+    private String region;
+    private String homepage;
+    @Column(columnDefinition = "TEXT")
+    private String bio;
+
+    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<MemberTag> tags = new ArrayList<>();
+
+
+    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<TravelPlan> travelPlans = new ArrayList<>();
 
     // 빌더 또는 all-args 생성자
     @Builder
@@ -89,4 +108,12 @@ public class Member {
         this.nickname = nickname;
     }
 
+    public void updateProfile(String nickname, Integer age, Gender gender, String region, String homepage, String bio) {
+        if(nickname != null) this.nickname = nickname;
+        if(age != null) this.age = age;
+        if(gender != null) this.gender = gender;
+        if(region != null) this.region = region;
+        if(homepage != null) this.homepage = homepage;
+        if(bio != null) this.bio = bio;
+    }
 }

--- a/src/main/java/com/project/Journey/login/member/domain/MemberTag.java
+++ b/src/main/java/com/project/Journey/login/member/domain/MemberTag.java
@@ -1,0 +1,28 @@
+package com.project.Journey.login.member.domain;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@Table(uniqueConstraints = @UniqueConstraint(columnNames = {"member_id", "tag"}))
+public class MemberTag {
+
+    @Id
+    @GeneratedValue
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    @Column(length = 6, nullable = false)
+    private String tag;
+
+    public MemberTag(Member member, String tag) {
+        this.member = member;
+        this.tag = tag;
+    }
+}

--- a/src/main/java/com/project/Journey/login/member/domain/TravelPlan.java
+++ b/src/main/java/com/project/Journey/login/member/domain/TravelPlan.java
@@ -1,0 +1,39 @@
+package com.project.Journey.login.member.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDate;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class TravelPlan {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    private String title;
+    private String country;
+    private String city;
+    private LocalDate startDate;
+    private LocalDate endDate;
+
+    public void update(String title,
+                       String country,
+                       String city,
+                       LocalDate startDate,
+                       LocalDate endDate) {
+        this.title = title;
+        this.country = country;
+        this.city = city;
+        this.startDate = startDate;
+        this.endDate = endDate;
+    }
+}

--- a/src/main/java/com/project/Journey/login/member/dto/ProfileResponse.java
+++ b/src/main/java/com/project/Journey/login/member/dto/ProfileResponse.java
@@ -1,0 +1,42 @@
+package com.project.Journey.login.member.dto;
+
+import com.project.Journey.login.member.domain.Gender;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Schema(description = "프로필 조회 응답 DTO")
+@Getter @Builder
+public class ProfileResponse {
+    @Schema(description = "회원 PK", example = "7")
+    private Long memberId;
+
+    @Schema(description = "로그인 ID", example = "testUser")
+    private String loginId;
+
+    @Schema(description = "닉네임", example = "모아찌")
+    private String nickname;
+
+    @Schema(description = "나이", example = "27")
+    private Integer age;
+
+    @Schema(description = "성별", example = "MALE")
+    private Gender gender;
+
+    @Schema(description = "지역", example = "경기도 성남시")
+    private String region;
+
+    @Schema(description = "홈페이지/SNS", example = "https://instagram.com/moAzzi")
+    private String homepage;
+
+    @Schema(description = "소개글", example = "캠핑·사진 좋아해요")
+    private String bio;
+
+    @Schema(description = "프로필 이미지 URL")
+    private String profileImage;
+
+    @Schema(description = "태그(최대 3개)")
+    private List<String> tags;
+}

--- a/src/main/java/com/project/Journey/login/member/dto/ProfileUpdateRequest.java
+++ b/src/main/java/com/project/Journey/login/member/dto/ProfileUpdateRequest.java
@@ -1,0 +1,42 @@
+package com.project.Journey.login.member.dto;
+
+import com.project.Journey.login.member.domain.Gender;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.List;
+
+@Schema(description = "프로필 수정 요청 DTO")
+@Setter @Getter
+public class ProfileUpdateRequest {
+
+    @Schema(description = "닉네임(선택)", example = "모아찌")
+    private String nickname;
+
+    @Schema(description = "나이(선택)", example = "29")
+    @Min(1) @Max(120)
+    private Integer age;
+
+    @Schema(description = "성별(선택)", example = "FEMALE")
+    private Gender gender;
+
+    @Schema(description = "지역(선택)", example = "서울특별시 강남구")
+    @Size(max = 50)
+    private String region;
+
+    @Schema(description = "홈페이지/SNS 링크(선택)")
+    @Size(max = 255)
+    private String homepage;
+
+    @Schema(description = "소개글(선택)")
+    @Size(max = 500)
+    private String bio;
+
+    @Schema(description = "태그 목록(최대 3개, 각 6자 이하)", example = "[\"캠핑좋아\",\"사진기사임\"]")
+    @Size(max = 3, message = "태그는 최대 3개까지만 저장할 수 있습니다")
+    private List<@Size(max = 6, message = "태그 한 글자는 6자 이하") String> tags;
+}

--- a/src/main/java/com/project/Journey/login/member/dto/TravelPlanRequest.java
+++ b/src/main/java/com/project/Journey/login/member/dto/TravelPlanRequest.java
@@ -1,0 +1,33 @@
+package com.project.Journey.login.member.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDate;
+
+@Schema(description = "여행 일정 등록·수정 요청 DTO")
+@Getter @Setter
+public class TravelPlanRequest {
+
+    @Schema(description = "제목", example = "여름 방콕 여행")
+    @NotBlank
+    @Size(max = 50)
+    private String title;
+
+    @Schema(description = "국가", example = "태국")
+    @NotBlank @Size(max = 30)
+    private String country;
+
+    @Schema(description = "도시", example = "방콕")
+    @NotBlank @Size(max = 30)
+    private String city;
+
+    @Schema(description = "출발일", example = "2025-08-01")
+    private LocalDate startDate;
+
+    @Schema(description = "도착일", example = "2025-08-10")
+    private LocalDate endDate;
+}

--- a/src/main/java/com/project/Journey/login/member/dto/TravelPlanResponse.java
+++ b/src/main/java/com/project/Journey/login/member/dto/TravelPlanResponse.java
@@ -1,0 +1,41 @@
+package com.project.Journey.login.member.dto;
+
+import com.project.Journey.login.member.domain.TravelPlan;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+@Schema(description = "여행 일정 응답 DTO")
+@Getter @Builder
+public class TravelPlanResponse {
+    @Schema(description = "일정 PK", example = "15")
+    private Long id;
+
+    @Schema(description = "제목")
+    private String title;
+
+    @Schema(description = "국가")
+    private String country;
+
+    @Schema(description = "도시")
+    private String city;
+
+    @Schema(description = "출발일")
+    private LocalDate startDate;
+
+    @Schema(description = "도착일")
+    private LocalDate endDate;
+
+    public static TravelPlanResponse of(TravelPlan tp) {
+        return TravelPlanResponse.builder()
+                .id(tp.getId())
+                .title(tp.getTitle())
+                .country(tp.getCountry())
+                .city(tp.getCity())
+                .startDate(tp.getStartDate())
+                .endDate(tp.getEndDate())
+                .build();
+    }
+}

--- a/src/main/java/com/project/Journey/login/member/repository/MemberTagRepository.java
+++ b/src/main/java/com/project/Journey/login/member/repository/MemberTagRepository.java
@@ -1,0 +1,12 @@
+package com.project.Journey.login.member.repository;
+
+import com.project.Journey.login.member.domain.Member;
+import com.project.Journey.login.member.domain.MemberTag;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface MemberTagRepository extends JpaRepository<MemberTag, Long> {
+    List<MemberTag> findByMember(Member member);
+    void deleteByMember(Member member);
+}

--- a/src/main/java/com/project/Journey/login/member/repository/TravelPlanRepository.java
+++ b/src/main/java/com/project/Journey/login/member/repository/TravelPlanRepository.java
@@ -1,0 +1,11 @@
+package com.project.Journey.login.member.repository;
+
+import com.project.Journey.login.member.domain.Member;
+import com.project.Journey.login.member.domain.TravelPlan;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface TravelPlanRepository extends JpaRepository<TravelPlan, Long> {
+    List<TravelPlan> findByMemberOrderByStartDateAsc(Member member);
+}

--- a/src/main/java/com/project/Journey/login/member/service/ProfileService.java
+++ b/src/main/java/com/project/Journey/login/member/service/ProfileService.java
@@ -1,0 +1,70 @@
+package com.project.Journey.login.member.service;
+
+import com.project.Journey.login.member.domain.Member;
+import com.project.Journey.login.member.domain.MemberTag;
+import com.project.Journey.login.member.dto.ProfileResponse;
+import com.project.Journey.login.member.dto.ProfileUpdateRequest;
+import com.project.Journey.login.member.repository.MemberRepository;
+import com.project.Journey.login.member.repository.MemberTagRepository;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service @RequiredArgsConstructor
+@Transactional
+public class ProfileService {
+
+    private final MemberRepository memberRepo;
+    private final MemberTagRepository tagRepo;
+
+    @Transactional(readOnly = true)
+    public ProfileResponse getMyProfile(Long memberId) {
+
+        Member m = memberRepo.findById(memberId)
+                .orElseThrow(() -> new IllegalArgumentException("회원 없음"));
+
+        return ProfileResponse.builder()
+                .memberId(m.getId())
+                .loginId(m.getLoginId())
+                .nickname(m.getNickname())
+                .age(m.getAge())
+                .gender(m.getGender())
+                .region(m.getRegion())
+                .homepage(m.getHomepage())
+                .bio(m.getBio())
+                .profileImage((m.getProfileImage()))
+                .tags(tagRepo.findByMember(m)
+                        .stream().map(MemberTag::getTag).toList())
+                .build();
+
+    }
+
+    public void updateProfile(Long memberId, ProfileUpdateRequest dto) {
+        Member m = memberRepo.findById(memberId)
+                .orElseThrow(() -> new IllegalArgumentException("회원 없음"));
+
+        m.updateProfile(
+                dto.getNickname(),
+                dto.getAge(),
+                dto.getGender(),
+                dto.getRegion(),
+                dto.getHomepage(),
+                dto.getBio()
+        );
+
+        tagRepo.deleteByMember(m);
+        if (dto.getTags() != null && !dto.getTags().isEmpty()) {
+
+            if (dto.getTags().size() > 3)
+                throw new IllegalArgumentException("태그는 최대 3개까지 가능합니다");
+
+            dto.getTags().forEach(t -> {
+                if (t.length() > 6)
+                    throw new IllegalArgumentException("태그 '" + t + "' 는 6자를 초과합니다");
+                tagRepo.save(new MemberTag(m, t));
+            });
+        }
+    }
+
+}

--- a/src/main/java/com/project/Journey/login/member/service/TravelPlanService.java
+++ b/src/main/java/com/project/Journey/login/member/service/TravelPlanService.java
@@ -1,0 +1,68 @@
+package com.project.Journey.login.member.service;
+
+import com.project.Journey.login.member.domain.Member;
+import com.project.Journey.login.member.domain.TravelPlan;
+import com.project.Journey.login.member.dto.TravelPlanRequest;
+import com.project.Journey.login.member.dto.TravelPlanResponse;
+import com.project.Journey.login.member.repository.MemberRepository;
+import com.project.Journey.login.member.repository.TravelPlanRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service @RequiredArgsConstructor
+@Transactional
+public class TravelPlanService {
+
+    private final MemberRepository memberRepo;
+    private final TravelPlanRepository planRepo;
+
+    public TravelPlanResponse addPlan(Long memberId, TravelPlanRequest req) {
+        Member m = memberRepo.findById(memberId)
+                .orElseThrow(() -> new IllegalArgumentException("회원 없음"));
+
+        TravelPlan saved = planRepo.save(
+                new TravelPlan(null,
+                        m,
+                        req.getTitle(),
+                        req.getCountry(),
+                        req.getCity(),
+                        req.getStartDate(),
+                        req.getEndDate())
+        );
+
+        return TravelPlanResponse.of(saved);
+    }
+
+    @Transactional(readOnly = true)
+    public List<TravelPlanResponse> listPlans(Long memberId) {
+        Member m = memberRepo.findById(memberId)
+                .orElseThrow(() -> new IllegalArgumentException("회원 없음"));
+
+        return planRepo.findByMemberOrderByStartDateAsc(m)
+                .stream().map(TravelPlanResponse::of).toList();
+
+    }
+
+    public TravelPlanResponse updatePlan(Long planId, TravelPlanRequest req) {
+        TravelPlan tp = planRepo.findById(planId)
+                .orElseThrow(() -> new IllegalArgumentException("일정 없음"));
+
+        tp.update(req.getTitle(),
+                req.getCountry(),
+                req.getCity(),
+                req.getStartDate(),
+                req.getEndDate());
+
+        return TravelPlanResponse.of(tp);
+    }
+
+    public void deletePlan(Long planId) {
+        planRepo.deleteById(planId);
+    }
+
+
+}
+


### PR DESCRIPTION
# Profile & TravelPlan 기능 통합 PR

## 1. 주요 변경 내역
 ### 1) Member Domain
- 프로필 확장 필드 `age`, `gender`, `region`, `homepage`, `bio`
- 연관관계
  - `MemberTag` (태그 최대 3개, 6자 제한)
  - `TravelPlan` (여행 일정 다대일)
  
 ### 2) API
- **GET  /api/members/{id}/profile**  
  내 프로필 조회
- **PATCH /api/members/{id}/profile**  
  프로필 수정(부분 업데이트) + 태그 재등록
- **POST  /api/members/{id}/plans**  
  일정 추가
- **GET   /api/members/{id}/plans**  
  일정 목록
- **PATCH /api/members/plans/{planId}**  
  일정 수정
- **DELETE /api/members/plans/{planId}**  
  일정 삭제
  
 
### 3) Swagger 문서
- `프로필 및 여행일정` 섹션 신설
  DTO(요청·응답) 스키마 및 제약조건 자동 노출
  
  
## 2. 테스트
- Postman 통합 시나리오 ✅  
  1. 회원(id=7) 프로필 조회 → 200  
  2. 프로필 이름·태그 수정 → 200  
  3. 태그 4개 요청 → 400 (제약 검증)  
  4. 일정 등록 → 200 & planId 반환  
  5. 일정 목록 조회(정렬 확인) → 200  
  6. 일정 수정/삭제 → 200
  
## 3. 기타
- **마이그레이션**: `member` 테이블 컬럼 추가, 신규 테이블 `member_tag`, `travel_plan` 생성
- **이슈 연결**: Closes #38 `프로필, 마이페이지 API 개발`

리뷰 부탁드립니다~