### PR TITLE
팔로우(팔로잉), 스토리 기능 개발

### DIFF
--- a/src/main/java/com/project/Journey/board/controller/PostController.java
+++ b/src/main/java/com/project/Journey/board/controller/PostController.java
@@ -30,7 +30,7 @@ import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
-@Tag(name = "게시글 관리", description = "게시판 관련 API")
+@Tag(name = "동행자 모집 게시글 관리", description = "동행자모집 게시판 관련 API")
 public class PostController {
 
     @Autowired
@@ -41,23 +41,22 @@ public class PostController {
     @Operation(summary = "동행자 모집 게시글 저장", description = """
             새로운 동행자 모집 게시글을 저장합니다.
             
-            -PostRequestDTO 필드 : userId, title, content, destination, startDate, endDate,
-            participants, user_id, country 필수
+            -post 필드 : userId, country, title, content, destination, startDate, endDate,
+            participants 필수
             
-            "post" : {
-              "userId": "미국여행자",
-              "country": "미국",
-              "title": "미국으로 떠나요",
-              "startDate": "2025-03-23",
-              "endDate": "2024-03-23",
-              "content": "미국 뉴욕여행같이해요~~!!!",
-              "participants" : 5,
-              "destination" : "미국"
-            }
-            "coverImage": (커버 이미지 파일),
-            "images": [(파일1), (파일2), (파일3)]
-            
-            response : post_id 반환
+            post : {
+            "userId": "미국여행자3", -> String
+            "country": "미국", -> String
+            "title": "미국 뉴욕으로~~~", -> String
+            "startDate": "2025-03-23", -> LocalDateTime
+            "endDate": "2024-03-23", -> LocalDateTime
+            "content": "미국 뉴욕여행같이해요~~!!!", ->String
+            "participants" : 5, -> int
+            "destination" : "미국" -> String
+            } 
+           
+            coverImage : (MultipartFile) 이미지파일.jpg 
+            images : ["이미지파일1.jpg", "이미지파일2.jpg", ...]
             """)
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "게시글이 성공적으로 저장되었습니다."),
@@ -65,8 +64,13 @@ public class PostController {
     })
     @PostMapping("api/posts/save")
     public ResponseEntity<Long> createPost(
-            @RequestPart("post") String postJson, //PostRequestDTO postRequestDTO,
+            @Parameter(description = "게시글 정보(JSON 형식)", required = true)
+            @RequestPart("post") String postJson,
+
+            @Parameter(description = "커버 이미지 파일", required = false)
             @RequestPart(value = "coverImage", required = false) MultipartFile coverImage,
+
+            @Parameter(description = "게시글에 첨부할 이미지 파일 리스트", required = false)
             @RequestPart(value = "images", required = false) List<MultipartFile> images) {
 
         try{
@@ -86,24 +90,30 @@ public class PostController {
 
     // 모든 게시글 조회
     @Operation(summary = "모든 게시글 조회", description = """
+            모든 게시글을 조회합니다.
             API 요청 예시 : http://localhost:8080/api/posts/getAll
             
             response :
-            {
-                    "user_id": "user1234",
-                    "title": "경주 여행",
-                    "content": "경주로 떠나요!",
-                    "destination": "한국",
-                    "start_date": "2024-12-30",
-                    "end_date": "2024-12-31",
-                    "max_participants": 7,
-                    "view_count": 0,
-                    "comment_count": 0,
-                    "created_at": "2025-02-17T23:22:25.970257",
-                    "updated_at": "2025-02-17T23:22:25.970257",
-                    "imageUrl": "https://s3.amazonaws.com/bucket-name/path/to/image2.jpg",
-                    "country": "한국"
+            [
+                {
+                    "postId": null,
+                        "user_id": "user1",
+                        "title": "유럽 여행 같이 가실 분 구합니다!",
+                        "content": "유럽 여행 같이가요~~!",
+                        "destination": "프랑스",
+                        "start_date": "2025-01-24",
+                        "end_date": "2024-01-26",
+                        "max_participants": 7,
+                        "view_count": 2,
+                        "comment_count": 6,
+                        "created_at": "2025-01-24T07:05:10.209152",
+                        "updated_at": "2025-01-24T07:07:54.341736",
+                        "coverImageUrl": "커버이미지주소.jpg",
+                        "profileImageUrl": "프로필이미지주소.jpg",
+                        "country": "국내",
+                        "imageUrls": ["이미지주소1.jpg", "이미지주소2.jpg"...]
                 } ....
+            ]
             """)
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "게시글 목록이 성공적으로 반환되었습니다."),
@@ -119,28 +129,19 @@ public class PostController {
 
     }
 
-
-    /*
-    // post_id로 게시글 조회
-    @GetMapping("api/posts/get/{post_id}")
-    public PostDTO getPostById(@PathVariable Long post_id) {
-        try{
-            return postService.getPostById(post_id);
-        }catch (Exception e){
-            throw new PostException("해당 게시글이 존재하지 않습니다.", HttpStatus.NOT_FOUND);
-        }
-
-    }
-    */
-
     // 게시글 삭제
-    @Operation(summary = "게시글 삭제", description = "특정 게시글을 삭제합니다.")
+    @Operation(summary = "게시글 삭제", description = """
+        특정 게시글을 삭제합니다.
+        response 예시
+        정상 삭제되었을 경우 : 1    
+    """)
     @ApiResponses(value = {
             @ApiResponse(responseCode = "204", description = "게시글이 성공적으로 삭제되었습니다."),
             @ApiResponse(responseCode = "404", description = "해당 게시글을 찾을 수 없습니다.")
     })
     @DeleteMapping("api/posts/delete/{post_id}")
-    public ResponseEntity<Void> deletePost( @Parameter(description = "삭제할 게시글의 post_id", required = true, example = "1") @PathVariable Long post_id) {
+    public ResponseEntity<Void> deletePost(
+            @Parameter(description = "삭제할 게시글의 post_id", required = true, example = "1") @PathVariable Long post_id) {
         try{
             postService.deletePost(post_id);
             return ResponseEntity.noContent().build();
@@ -152,49 +153,63 @@ public class PostController {
 
     //게시글 수정
     @Operation(summary = "게시글 수정", description = """
-            특정 게시글을 수정합니다. 
+            특정 게시글을 수정합니다.
             -> title, content, destination, start_date, end_date,
-            max_participants, user_id, country, imageUrl 필드 중 수정하고 싶은 필드를 
+            max_participants, country, coverImageUrl, imagesUrl 필드 중 수정하고 싶은 필드를 
             수정하고 업데이트 
             
-            request 예시
-            {
-              "title": "이탈리아 여행",
-              "content": "이탈리아로 떠나요! -> 글 업데이트~~",
-              "destination": "이탈리아",
-              "start_date": "2024-12-30",
-              "end_date": "2024-12-31",
-              "max_participants": 7,
-              "user_id" : "user1234",
-              "imageUrl": "https://s3.amazonaws.com/bucket-name/path/to/image2.jpg",
-              "country" : "이탈리아"
+            
+            1. /api/posts/getIncrementView/{postId}로 업데이트 할 게시글을 불러옴
+            
+            2. /api/posts/update/{post_id}로 json에서 coverImage를 삭제하고 싶으면 빈 문자열("")로, 첨부파일이미지를 삭제하고 싶으면 해당 이미지 주소를 지우면 됩니다!(남기고 싶은 이미지는 지우지 않으면 유지됨)
+               만약 새로 커버 이미지를 업데이트 하고 싶으면 newCoverImage를 key값으로 두고 value를 MultipartFile 객체로,
+               첨부파일 이미지를 추가하고 싶으면 newImages를 key값으로 두고 value를 List<MultipartFile>로 지정해주고\s
+               API를 호출하면 됩니다!
+               
+               
+            key : post, value: json( /api/posts/getIncrementView/{postId}의 response객체)
+             {
+                "postId": 8,
+                "user_id": "여행자",
+                "title": "캘리포니아 같이 가실 분 구해요!!! - 게시글 수정", -> 수정 가능
+                "content": "이번 방학때 캘리포니아에 가게 됐는데 혼자 여행가게 되었습니다!\\n같이 동행하실 분 구해요", -> 수정 가능
+                "destination": "미국 캘리포니아", -> 수정 가능
+                "start_date": "2025-03-23", -> 수정 가능
+                "end_date": "2025-03-27", -> 수정 가능
+                "max_participants": 7, -> 수정 가능
+                "view_count": 11,
+                "comment_count": 0,
+                "created_at": "2025-04-30T19:55:54.950551",
+                "updated_at": "2025-05-02T17:18:46.888407",
+                "coverImageUrl": "커버이미지url.jpg", -> 수정 가능
+                "profileImageUrl": "", 
+                "country": "국내", -> 수정 가능
+                "imageUrls": ["첨부이미지url.jpg"] -> 수정 가능
             }
-                    
-                    
+                       
+            추가하고 싶은 이미지가 있다면           
+            key : newImages , value : List<MultipartFile>\s
+            key : newCoverImage, value : MultipartFile 
+            추가       
                     """)
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "게시글이 성공적으로 수정되었습니다."),
             @ApiResponse(responseCode = "400", description = "수정 요청값이 잘못되었습니다."),
             @ApiResponse(responseCode = "404", description = "해당 게시글을 찾을 수 없습니다.")
     })
-    /*
-    @PutMapping("api/posts/update/{post_id}")
-    public ResponseEntity<String> updatePost( @Parameter(description = "수정할 게시글의 ID", required = true, example = "1") @PathVariable Long post_id,
-                                              @RequestBody @Parameter(description = "게시글 수정에 필요한 정보", required = true) PostDTO postDTO){
-        try{
-            postService.updatePostById(post_id, postDTO);
-            return ResponseEntity.ok("게시글이 성공적으로 수정되었습니다.");
-        } catch (Exception e){
-            throw new PostException("게시글 수정 중 오류가 발생했습니다.", HttpStatus.BAD_REQUEST);
-        }
 
-    }
-    */
     @PutMapping(value = "/api/posts/update/{post_id}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<String> updatePost(
+            @Parameter(description = "수정할 게시글의 post_id", required = true)
             @PathVariable Long post_id,
+
+            @Parameter(description = "업데이트 할 게시글 정보(JSON 형식)", required = true)
             @RequestPart("post") String postJson,
+
+            @Parameter(description = "추가할 첨부파일 이미지(List<MultipartFile>)")
             @RequestPart(value = "newImages", required = false) List<MultipartFile> newImages,
+
+            @Parameter(description = "변경할 커버 이미지 (MultipartFile)")
             @RequestPart(value = "newCoverImage", required = false) MultipartFile newCoverImage
     ) {
         try {
@@ -210,17 +225,6 @@ public class PostController {
             throw new PostException("게시글 수정 중 오류가 발생했습니다.", HttpStatus.BAD_REQUEST);
         }
     }
-
-
-
-
-
-
-
-
-
-
-
 
     //조회수가 높은 순서대로 게시물 조회
 
@@ -328,33 +332,6 @@ public class PostController {
     }
 
 
-    @Operation(summary = "사용자 게시글 조회", description = """
-            페이지네이션을 적용하여 page와 size를 지정하여 게시글을 반환합니다.
-            
-            API 요청 예시 : http://localhost:8080/api/posts/getPostByPage?page=0&size=5
-            
-            -> 첫 페이지의 첫 페이지의 5개 게시글 반환
-            [
-             {
-                    "user_id": "travle",
-                    "title": "내슈빌로 가요",
-                    "content": "내슈빌 같이 갈 사람!",
-                    "destination": "내슈빌",
-                    "start_date": "2025-01-07",
-                    "end_date": "2025-01-08",
-                    "max_participants": 5,
-                    "view_count": 7,
-                    "comment_count": 1,
-                    "created_at": "2025-01-08T10:51:47.845289",
-                    "updated_at": "2025-01-08T10:51:47.845289",
-                    "imageUrl": null,
-                    "country": "미국"
-                }
-                ....
-            ]
-            
-            
-            """)
     @GetMapping("api/posts/getPostByPage")
     public List<PostDTO> getPostByPage(
             @RequestParam(defaultValue = "0") int page,
@@ -365,12 +342,13 @@ public class PostController {
 
     //국가별 게시글 반환 :
     //예시 : http://localhost:8080/api/posts/getPostByCountry/한국?page=0&size=5
+   /*
     @Operation(summary = "국가별 게시글 조회", description = """
             페이지네이션을 적용하여 page와 size를 지정하여 국가별 커뮤니티 게시글을 반환합니다.
-            
+
             API 요청 예시 : http://localhost:8080/api/posts/getPostByCountry/한국?page=0&size=5
-            
-            response : 
+
+            response :
             [
              {
                     "user_id": "user1234",
@@ -403,9 +381,9 @@ public class PostController {
                     "country": "한국"
                 },....
             ]
-            
-            
-            """)
+
+
+            """)*/
     @GetMapping("api/posts/getPostByCountry/{country}")
     public List<PostDTO> getPostByCountry(
             @PathVariable String country,
@@ -438,8 +416,50 @@ public class PostController {
 
 
     //랜덤 동행자 게시글 가져오기
+    @Operation(summary = "랜덤 동행자 게시글 조회", description = """
+           랜덤으로 동행자 모집 게시글을 count 개수 만큼 반환합니다.
+           
+           /api/posts/random?count=3 처럼 count 값을 지정해주면 
+           count 개수 만큼 게시글이 반환됨
+           
+            response예시 = [
+            {
+            "postId": 2,
+            "destination": "아이슬란드",
+            "startDate": "2025-10-27",
+            "endDate": "2025-11-02",
+            "max_participants": 4,
+            "title": "함께 아이슬란드에서 좋은 추억쌓고 오실 분! 여성분들과 함께 하고 싶습니다",
+            "coverImageUrl": "image.jpg",
+            "country": "국내" -> 커뮤니티명
+            },
+            {
+            "postId": 15,
+            "destination": "한국",
+            "startDate": "2024-12-30",
+            "endDate": "2024-12-31",
+            "max_participants": 7,
+            "title": "독도 여행",
+            "coverImageUrl": null,
+            "country": "국내"
+            },
+            {
+            "postId": 1,
+            "destination": "내슈빌",
+            "startDate": "2025-01-07",
+            "endDate": "2025-01-08",
+            "max_participants": 5,
+            "title": "내슈빌로 가요",
+            "coverImageUrl": null,
+            "country": "국내"
+            }
+            ]
+           
+            """
+    )
     @GetMapping("api/posts/random")
     public ResponseEntity<List<PostPageResponseDTO>> getRandomPosts(
+            @Parameter(description = "랜덤으로 가져올 동행자 모집 게시글 개수")
             @RequestParam(value = "count", defaultValue = "3") int count) {
 
         List<PostPageResponseDTO> randomPosts = postService.getRandomPosts(count);
@@ -447,10 +467,40 @@ public class PostController {
     }
 
     //동행자 모집 검색 & 페이지네이션
+
+
+
+    @Operation(summary = "동행자 모집 게시글 페이지네이션", description = """
+            
+            예시 : 
+            기본 호출
+            http://localhost:8080/api/posts/searchPost
+            
+            country, page, size 지정
+            http://localhost:8080/api/posts/searchPost?country=국내&page=1&size=6
+           
+           
+           제목으로 검색 : (제목에 '여행'이라는  단어가 있는 게시글 검색)
+           http://localhost:8080/api/posts/searchPost?title=여행
+            
+           작성자로 검색 : (작성자가 '산책자'인 게시글 검색) 
+           http://localhost:8080/api/posts/searchPost?user_id=산책자
+           
+           번호(postId)로 검색 : (postId가 9번인 게시글 검색) 
+           http://localhost:8080/api/posts/searchPost?postId=9
+           
+           여행시작일, 종료일로 검색..... (2025-04-01부터 2025-05-01 기간 내의 게시글 검색
+           -> http://localhost:8080/api/posts/searchPost?startDate=2025-04-01&endDate=2025-05-01
+            """
+    )
     @GetMapping("/api/posts/searchPost")
     public PostSearchResponse searchPosts(
+            @Parameter(description = "검색 파라미터 : country, title, user_id, startDate, endDate, postId ")
             @ModelAttribute PostSearchRequest request,
+            @Parameter(description = "검색할 페이지 번호")
             @RequestParam(defaultValue = "1") int page,
+
+            @Parameter(description = "페이지 당 가져올 게시글 수")
             @RequestParam(defaultValue = "12") int size
     ) {
         request.setPage(page);           // 필수: request 내부에 페이지 정보 세팅

--- a/src/main/java/com/project/Journey/community/controller/CommunityController.java
+++ b/src/main/java/com/project/Journey/community/controller/CommunityController.java
@@ -11,6 +11,7 @@ import com.project.Journey.board.service.PostService;
 import com.project.Journey.community.dto.*;
 import com.project.Journey.community.entity.Community;
 import com.project.Journey.community.service.CommunityService;
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
@@ -37,9 +38,24 @@ public class CommunityController {
     private final CommunityService communityService;
 
 
+    @Operation(summary = "커뮤니티 게시글 생성", description = """
+            JSON 데이터와 이미지 파일을 포함하여 새 커뮤니티 게시글을 생성합니다.
+            
+            request 예시 : form-data -> key : data, value :{
+            "user_id": "구름",
+            "country": "국내",
+            "title": "요즘 제주도 날씨는 어떤가요?",
+            "content": "저번주에 다녀온 지인 얘기 들어보니까 서울보다는 따뜻하다고 그러더라고요. 서울은 너무 요즘 너무 추운데 패딩은 입기 싫고 어떤 걸 입어야 할 지 고민중입니다... 지금 제주도에 계신 분들은 어떻게 입고 갔는지 궁금해서 여쭤봅니다!"
+            },  key : images, value = 이미지파일
+           
+            """)
     @PostMapping(value = "/api/community/save", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<Long> createPost(
+
+            @Parameter(description = "커뮤니티 게시글 데이터 (JSON 문자열)")
             @RequestPart("data") String data, //@Parameter(description = "게시글 정보", required = true) CommunityRequestDTO communityRequestDTO
+
+            @Parameter(description = "이미지 파일들", required = false)
             @RequestPart(value = "images", required = false) List<MultipartFile> images) {
         if (data == null) {
             throw new IllegalArgumentException("요청 데이터가 올바르지 않습니다.");
@@ -61,8 +77,38 @@ public class CommunityController {
     }
 
     // 특정 게시글 조회 (조회수 증가 반영)
+    @Operation(summary = "게시글 단건 조회", description = """
+    게시글 ID를 통해 게시글 상세 정보를 조회합니다.
+    
+    API 요청 예시
+    http://localhost:8080/api/community/getPostByPostId/{communityPostId}
+    
+    response 예시 :
+    
+            response : {
+                "user_id": "구름",
+                "country": "국내",
+                "title": "요즘 제주도 날씨는 어떤가요?",
+                "content": "저번주에 다녀온 지인 얘기 들어보니까 서울보다는 따뜻하다고 그러더라고요.
+            서울은 너무 요즘 너무 추운데 패딩은 입기 싫고 어떤 걸 입어야 할 지 고민중입니다...
+            지금 제주도에 계신 분들은 어떻게 입고 갔는지 궁금해서 여쭤봅니다!",
+                "view_count": 999,
+                "comment_count": 0,
+                "created_at": "2025-03-21T01:17:38.896685",
+                "updated_at": "2025-03-21T01:17:38.896685",
+                "profileImageUrl": null,
+                "imageUrls": [
+                    "이미지1.jpg",
+                    "이미지2.jpg"
+                ],
+                "communityPostId": 39
+            }
+    
+    """)
     @GetMapping("/api/community/getPostByPostId/{communityPostId}")
-    public CommunityResponseDTO getCommunityPost(@PathVariable Long communityPostId) {
+    public CommunityResponseDTO getCommunityPost(
+            @Parameter(description = "커뮤니티 게시글 ID", required = true)
+            @PathVariable Long communityPostId) {
         return communityService.getPostByCommunityPostId(communityPostId);
     }
 
@@ -81,9 +127,44 @@ public class CommunityController {
 */
 
     //오늘의 핫 게시물 기능 (페이지네이션 추가)
+    @Operation(summary = "오늘의 핫 게시글 조회", description = """
+            조회수가 높은 게시글을 페이지네이션하여 가져옵니다.
+            
+            API 호출 예시 : http://localhost:8080/api/community/hot-posts?page=1&size=3
+            
+            response 예시 : {
+              "totalCount": 182,
+              "currentPage": 1,
+              "posts": [
+                {
+                  "country": "일본",
+                  "title": "오사카 3박 4일 너무 즐거웠어요!",
+                  "createdAt": "2025-05-02",
+                  "communityPostId": 353
+                },
+                {
+                  "country": "미국",
+                  "title": "다들 환전은 어떻게 해서 가시나요?",
+                  "createdAt": "2025-04-13",
+                  "communityPostId": 1
+                },
+                {
+                  "country": "프랑스",
+                  "title": "날씨가 너무 좋아서 행복했어요..",
+                  "createdAt": "2025-04-11",
+                  "communityPostId": 171
+                }
+              ]
+            }
+            
+            
+            """)
     @GetMapping("/api/community/hot-posts")
     public ResponseEntity<Map<String, Object>> getHotPosts(
+            @Parameter(description = "페이지 번호", example = "1")
             @RequestParam(defaultValue = "1") int page,
+
+            @Parameter(description = "페이지당 게시글 수", example = "3")
             @RequestParam(defaultValue = "3") int size) {
 
         Map<String, Object> response = communityService.getHotPosts(page, size);
@@ -94,10 +175,42 @@ public class CommunityController {
 
 
     //게시글 수정
+    @Operation(summary = "게시글 수정", description = """ 
+            커뮤니티 게시글 ID에 해당하는 게시글을 수정합니다.
+            
+            1. localhost:8080/api/community/getPostByPostId/{communityPostId}로 업데이트 할 게시글을 불러옴
+            
+            2. http://localhost:8080/api/community/update/{CommunityPostId} 로 post라는 key값으로 
+            value 값을 JSON 문자열을 넣고 새로운 이미지를 추가하고 싶으면 newImages라는 key값으로 value를 이미지파일로 추가해줍니다.(여러개 가능) 
+            만약 삭제하고 싶은 이미지가 있으면 1.에서 불러온 imageUrls 리스트에서 삭제할 url을 지워주고 api를 호출해주면 됩니다.                                           그리고 JSON 문자열은 country, title, content 내용만 수정이 가능합니다!
+            
+            
+            request 예시{
+                "user_id": "커뮤니티테스트유저",
+                "country": "국내",
+                "title": "두번째변경한테스트제목~~~~~",
+                "content": "두번째 변경한내용입니다",
+                "view_count": 1,
+                "comment_count": 0,
+                "created_at": "2025-04-22T23:44:59.781954",
+                "updated_at": "2025-04-22T23:44:59.781954",
+                "profileImageUrl": null,
+                "imageUrls": [
+                    "이미지.jpg"
+                ],
+                "communityPostId": 350
+            }
+            """)
     @PutMapping("/api/community/update/{CommunityPostId}")
-    public ResponseEntity<Void> updatePost(@PathVariable Long CommunityPostId,
-                                           @RequestPart("post") String postJson,
-                                           @RequestPart(value = "newImages", required = false) List<MultipartFile> newImages) {
+    public ResponseEntity<Void> updatePost(
+            @Parameter(description = "커뮤니티 게시글 ID")
+            @PathVariable Long CommunityPostId,
+
+            @Parameter(description = "수정할 게시글 데이터 (JSON 문자열)")
+            @RequestPart("post") String postJson,
+
+            @Parameter(description = "새 이미지 파일들", required = false)
+            @RequestPart(value = "newImages", required = false) List<MultipartFile> newImages) {
         try {
             ObjectMapper mapper = new ObjectMapper();
             //LocalDateTime 처리 가능하도록 설정
@@ -125,30 +238,197 @@ public class CommunityController {
      */
 
     //게시글 삭제
+    @Operation(summary = "게시글 삭제", description = "커뮤니티 게시글 ID에 해당하는 게시글을 삭제합니다.")
     @DeleteMapping("/api/community/DeletePosts/{CommunityPostId}")
-    public ResponseEntity<Void> deleteCommunityPost(@PathVariable Long CommunityPostId){
+    public ResponseEntity<Void> deleteCommunityPost(
+            @Parameter(description = "커뮤니티 게시글 ID")
+            @PathVariable Long CommunityPostId){
         communityService.deleteCommunityPost(CommunityPostId);
         return ResponseEntity.noContent().build();
     }
 
     //메인 페이지 - 오늘은 어떤 이야기를 나누었을까요? (조회수가 가장 높은 게시글 count 수만큼 반환)
+    @Operation(summary = "메인 핫 게시글 조회", description = """
+            조회수가 가장 높은 게시글을 count 개수만큼 반환합니다.
+API 호출 예시 :
+가져올 게시글들의 개수(count)를 지정하고 호출합니다.             
+http://localhost:8080/api/community/main-hot-posts?count=3
+        
+response 예시 : 
+[
+{
+"postId": 8,
+"user_id": "바다",
+"profileImageUrl":"image.jpg",
+"imageUrls": [
+"이미지4.jpg",
+"이미지3.jpg"
+],
+"content": "오늘 난바역 근처에 있는 타코야끼 집에서 타코야끼를 먹었는데 너무 맛있었어요, 타코야끼 먹으니까  일본온 느낌도 나고 너무 좋네요",
+"country": "일본"
+},
+{
+"postId": 1,
+"user_id": "user1234",
+"profileImageUrl": "",
+"imageUrls": [],
+"content": "이탈리아로 떠나요!",
+"country": "이탈리아"
+},
+{
+"postId": 39,
+"user_id": "테스트유저2",
+"profileImageUrl": null,
+"imageUrls": [
+"이미지1.jpg",
+"이미지2.jpg"
+],
+"content": "내용 입력 테스트2",
+"country": "국내"
+}
+]
+
+            """)
     @GetMapping("/api/community/main-hot-posts")
-    public ResponseEntity<List<CommunityMainHotPostDTO>> getHotPosts(@RequestParam(defaultValue = "3") int count) {
+    public ResponseEntity<List<CommunityMainHotPostDTO>> getHotPosts(
+            @Parameter(description = "반환할 게시글 수", example = "3")
+            @RequestParam(defaultValue = "3") int count) {
         List<CommunityMainHotPostDTO> hotPosts = communityService.getHotPosts(count);
         return ResponseEntity.ok(hotPosts);
     }
 
     //검색 API 개발
 
+    @Operation(summary = "커뮤니티 게시글 검색(페이지네이션)", description = """
+            
+            국가(커뮤니티), 제목, 작성자, 여행 기간(여행 시작일, 종료일)의 조건으로 게시글을 검색합니다.
+           
+            API 호출 예시: 
+                       
+            * API 테스트 default(country는 입력 필수) : http://localhost:8080/api/community/search?country=국내
+            
+            * 게시글 제목으로 검색 : http://localhost:8080/api/community/search?country=국내&title=맛집
+            
+            * 작성자로 검색 : http://localhost:8080/api/community/search?country=국내&writer=구름
+            
+            * 시작일~종료일로 검색 : http://localhost:8080/api/community/search?country=국내&starteDate=2025-03-01&endDate=2025-04-01
+            
+            * 페이지, 게시글 갯수 지정 후 검색 :  http://localhost:8080/api/community/search?country=국내&page=1&recordSize=12
+           
+            response 예시 : 
+            
+            {
+              "communityList": [
+                {
+                  "communityPostId": 353,
+                  "title": "s3삭제테스트입니다",
+                  "user_id": "테스트테스트",
+                  "createdAt": "2025-05-02"
+                },
+                {
+                  "communityPostId": 349,
+                  "title": "에어비엔비가 나을까요?",
+                  "user_id": "강아지",
+                  "createdAt": "2025-04-20"
+                },
+                {
+                  "communityPostId": 348,
+                  "title": "가족끼리 갈만한 국내 여행지 추천해주세요",
+                  "user_id": "마요네즈",
+                  "createdAt": "2025-04-20"
+                },
+                {
+                  "communityPostId": 347,
+                  "title": "속초 좋네요~",
+                  "user_id": "사랑",
+                  "createdAt": "2025-04-20"
+                },
+                {
+                  "communityPostId": 346,
+                  "title": "이번주 강릉 날씨 많이 춥겠죠ㅜㅜ?.",
+                  "user_id": "당근",
+                  "createdAt": "2025-04-20"
+                },
+                {
+                  "communityPostId": 345,
+                  "title": "서울로 여행가는데 종로 맛집 추천해주세요!",
+                  "user_id": "인형",
+                  "createdAt": "2025-04-20"
+                },
+                {
+                  "communityPostId": 344,
+                  "title": "금요일 오전 7시 제주행 에어부산이요....",
+                  "user_id": "사탕",
+                  "createdAt": "2025-04-20"
+                },
+                {
+                  "communityPostId": 343,
+                  "title": "다음주에 부산 가는데 너무 설레요~",
+                  "user_id": "바다",
+                  "createdAt": "2025-04-20"
+                },
+                {
+                  "communityPostId": 342,
+                  "title": "방콕 여행 갈려구요~",
+                  "user_id": "테스트유저22",
+                  "createdAt": "2025-04-19"
+                },
+                {
+                  "communityPostId": 341,
+                  "title": "하와이 여행 갈려구요~",
+                  "user_id": "테스트유저",
+                  "createdAt": "2025-04-19"
+                },
+                {
+                  "communityPostId": 340,
+                  "title": "국내 여행지 추천",
+                  "user_id": "산",
+                  "createdAt": "2025-04-19"
+                },
+                {
+                  "communityPostId": 339,
+                  "title": "속초 날씨는 어떤가요?",
+                  "user_id": "속초러버",
+                  "createdAt": "2025-04-16"
+                }
+              ],
+              "pagination": {
+                "totalRecordCount": 98, -> 전체 데이터 수
+                "totalPageCount": 9, -> 전체 페이지 수
+                "startPage": 1, -> 첫 페이지 번호
+                "endPage": 9, -> 끝 페이지 번호
+                "limitStart": 0, -> LIMIT 시작 위치
+                "existPrevPage": false, -> 이전 페이지 존재 여부
+                "existNextPage": true -> 다음 페이지 존재 여부
+              }
+            }
+      
+            """)
     @GetMapping("/api/community/search")
     public CommunitySearchResponseDTO searchPosts(
+
+            @Parameter(description = "국가", required = true)
             @RequestParam String country,
+
+            @Parameter(description = "게시글 번호", required = false)
             @RequestParam(required = false) Long number,
+
+            @Parameter(description = "게시글 제목", required = false)
             @RequestParam(required = false) String title,
+
+            @Parameter(description = "작성자 ID", required = false)
             @RequestParam(required = false) String writer,
+
+            @Parameter(description = "검색 시작일", required = false, example = "2023-01-01")
             @RequestParam(required = false) @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate startDate,
+
+            @Parameter(description = "검색 종료일", required = false, example = "2023-12-31")
             @RequestParam(required = false) @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate endDate,
+
+            @Parameter(description = "페이지 번호", example = "1")
             @RequestParam(defaultValue = "1") int page,
+
+            @Parameter(description = "페이지당 게시글 수", example = "10")
             @RequestParam(defaultValue = "10") int recordSize
     ) {
         SearchDTO searchDTO = new SearchDTO();

--- a/src/main/java/com/project/Journey/login/follow/controller/FollowController.java
+++ b/src/main/java/com/project/Journey/login/follow/controller/FollowController.java
@@ -1,0 +1,46 @@
+package com.project.Journey.login.follow.controller;
+
+import com.project.Journey.login.follow.dto.FollowRequestDTO;
+import com.project.Journey.login.follow.dto.FollowResponseDTO;
+import com.project.Journey.login.follow.service.FollwService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+public class FollowController {
+
+    private final FollwService follwService;
+
+    //팔로우
+    //http://localhost:8080/api/follow?myLoginId=user1
+    @PostMapping("/api/follow")
+    public ResponseEntity<Void> follow(@RequestParam String myLoginId,  @RequestBody FollowRequestDTO request){
+        follwService.follow(myLoginId, request.getTargetLoginId());
+        return ResponseEntity.ok().build();
+    }
+
+    //언팔로우
+    //http://localhost:8080/api/unfollow?myLoginId=user3&targetId=user1
+    @DeleteMapping("/api/unfollow")
+    public ResponseEntity<Void> unfollow(@RequestParam String myLoginId, @RequestParam String targetId) {
+        follwService.unfollow(myLoginId, targetId);
+        return ResponseEntity.ok().build();
+    }
+
+    //팔로잉한 사람들 리스트 가져오기
+    //http://localhost:8080/api/follow/following?memberLoginId=user1
+    @GetMapping("/api/follow/following")
+    public List<FollowResponseDTO> getFollowing(@RequestParam String memberLoginId){
+        return follwService.getFollowingList(memberLoginId);
+    }
+
+    //팔로우한 사람들 리스트 가져오기
+    @GetMapping("/api/follow/followers")
+    public List<FollowResponseDTO> getFollowers(@RequestParam String memberLoginId){
+        return follwService.getFollowerList(memberLoginId);
+    }
+}

--- a/src/main/java/com/project/Journey/login/follow/dto/FollowRequestDTO.java
+++ b/src/main/java/com/project/Journey/login/follow/dto/FollowRequestDTO.java
@@ -1,0 +1,12 @@
+package com.project.Journey.login.follow.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class FollowRequestDTO {
+    private String targetLoginId; //팔로우할 대상 사용자의 로그인 아이디
+
+    //private Long targetId; // 팔로우할 대상 사용자 ID
+}

--- a/src/main/java/com/project/Journey/login/follow/dto/FollowResponseDTO.java
+++ b/src/main/java/com/project/Journey/login/follow/dto/FollowResponseDTO.java
@@ -1,0 +1,22 @@
+package com.project.Journey.login.follow.dto;
+
+import com.project.Journey.login.member.domain.Member;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class FollowResponseDTO {
+
+    private Long memberId;
+    private String username;
+
+    private String profileImageUrl;
+
+
+    public FollowResponseDTO(Member member){
+        this.memberId = member.getId();
+        this.username = member.getLoginId();
+        this.profileImageUrl = member.getProfileImage();
+    }
+}

--- a/src/main/java/com/project/Journey/login/follow/entity/Follow.java
+++ b/src/main/java/com/project/Journey/login/follow/entity/Follow.java
@@ -1,0 +1,30 @@
+package com.project.Journey.login.follow.entity;
+
+import com.project.Journey.login.member.domain.Member;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(uniqueConstraints = @UniqueConstraint(columnNames = {"follower_id", "following_id"}))
+@Setter
+@Getter
+public class Follow {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "follower_id")
+    private Member follower; //나 : 팔로우를 요청한 사람
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "following_id")
+    private Member following; //상대 : 팔로우 당한 사람
+
+    @Column(name = "created_at")
+    private LocalDateTime createdAt = LocalDateTime.now();
+}

--- a/src/main/java/com/project/Journey/login/follow/repository/FollowRepository.java
+++ b/src/main/java/com/project/Journey/login/follow/repository/FollowRepository.java
@@ -1,0 +1,21 @@
+package com.project.Journey.login.follow.repository;
+
+import com.project.Journey.login.follow.entity.Follow;
+import com.project.Journey.login.member.domain.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface FollowRepository extends JpaRepository<Follow, Long> {
+    boolean existsByFollowerAndFollowing(Member follower, Member following);
+    Optional<Follow> findByFollowerAndFollowing(Member follower, Member following);
+
+    //내가 팔로우한 사람들
+    List<Follow> findByFollower(Member follower);
+
+    //나를 팔로우한 사람들
+    List<Follow> findByFollowing(Member following);
+}

--- a/src/main/java/com/project/Journey/login/follow/service/FollwService.java
+++ b/src/main/java/com/project/Journey/login/follow/service/FollwService.java
@@ -1,0 +1,89 @@
+package com.project.Journey.login.follow.service;
+
+import com.project.Journey.login.follow.dto.FollowResponseDTO;
+import com.project.Journey.login.follow.entity.Follow;
+import com.project.Journey.login.follow.repository.FollowRepository;
+import com.project.Journey.login.member.domain.Member;
+import com.project.Journey.login.member.repository.MemberRepository;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.NoSuchElementException;
+
+@Service
+@RequiredArgsConstructor
+public class FollwService {
+
+    private final FollowRepository followRepository;
+    private final MemberRepository memberRepository;
+
+    //팔로우
+    public void follow(String myLoginId, String targetLoginId){
+        Member me = memberRepository.findByLoginId(myLoginId).orElseThrow(() -> new EntityNotFoundException("내 계정이 존재하지 않습니다: " + myLoginId));
+
+        Member target = memberRepository.findByLoginId(targetLoginId).orElseThrow(() -> new EntityNotFoundException("팔로우 대상 계정이 존재하지 않습니다: " + targetLoginId));
+
+        if(followRepository.existsByFollowerAndFollowing(me, target)){
+            throw new IllegalStateException(me+"는 이미"+target+"을 팔로우하고 있습니다.");
+        }
+
+        Follow follow = new Follow();
+        follow.setFollower(me);
+        follow.setFollowing(target);
+        followRepository.save(follow);
+
+    }
+
+    //언팔로우
+    public void unfollow(String myLoginId, String targetLoginId){
+        Member me = memberRepository.findByLoginId(myLoginId).orElseThrow(() -> new EntityNotFoundException("내 계정이 존재하지 않습니다: " + myLoginId));
+
+        Member target = memberRepository.findByLoginId(targetLoginId)
+                .orElseThrow(() -> new EntityNotFoundException("언팔로우 대상 계정이 존재하지 않습니다: " + targetLoginId));
+
+        Follow follow = followRepository.findByFollowerAndFollowing(me, target)
+                .orElseThrow(()-> new IllegalStateException("팔로우 관계가 존재하지 않습니다."));
+
+        followRepository.delete(follow);
+    }
+
+    //팔로잉 리스트 가져오기
+    public List<FollowResponseDTO> getFollowingList(String LoginId){
+        Member member = memberRepository.findByLoginId(LoginId).orElseThrow(() -> new EntityNotFoundException(LoginId+"의 계정이 존재하지 않습니다."));
+
+        List<Follow> follows = followRepository.findByFollower(member);
+        List<FollowResponseDTO> result = new ArrayList<>();
+
+        for(Follow follow : follows){
+            Member following = follow.getFollowing();
+            FollowResponseDTO followResponseDTO = new FollowResponseDTO(following);
+            result.add(followResponseDTO);
+        }
+
+        return result;
+    }
+
+    //팔로워 리스트 가져오기
+    public List<FollowResponseDTO> getFollowerList(String LoginId){
+        Member member = memberRepository.findByLoginId(LoginId).orElseThrow(() -> new EntityNotFoundException(LoginId+"의 계정이 존재하지 않습니다."));
+        List<Follow> follows = followRepository.findByFollowing(member);
+
+        List<FollowResponseDTO> result = new ArrayList<>();
+        for(Follow follow : follows){
+            Member follower = follow.getFollower();
+            FollowResponseDTO followResponseDTO = new FollowResponseDTO(follower);
+            result.add(followResponseDTO);
+        }
+        return result;
+    }
+
+
+    //member id로 가져오기
+    private Member getMember(Long id) {
+        return memberRepository.findById(id)
+                .orElseThrow(() -> new NoSuchElementException("사용자를 찾을 수 없습니다."));
+    }
+}

--- a/src/main/java/com/project/Journey/story/controller/StoryController.java
+++ b/src/main/java/com/project/Journey/story/controller/StoryController.java
@@ -1,0 +1,99 @@
+package com.project.Journey.story.controller;
+
+import com.project.Journey.story.dto.StoryRequestDTO;
+import com.project.Journey.story.dto.StoryResponseDTO;
+import com.project.Journey.story.service.StoryService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/story")
+public class StoryController {
+
+    private final StoryService storyService;
+
+
+    //스토리 업로드
+    @PostMapping(
+    consumes = MediaType.MULTIPART_FORM_DATA_VALUE,
+    produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<Void> uploadStory(
+            @RequestParam String memberLoginId,
+            @RequestPart MultipartFile imageFile,
+           @RequestParam(required = false) String expireAt
+            ){
+        storyService.uploadStory(memberLoginId, imageFile, expireAt);
+        return ResponseEntity.status(201).build();
+    }
+
+    //내가 팔로잉한 사람들의 최신 스토리 최대 N개 조회
+    //http://localhost:8080/api/story/following/recent?memberLoginId=user1&limit=4
+    @GetMapping("/following/recent")
+    public List<StoryResponseDTO> getRecentFollowingStories(
+            @RequestParam String memberLoginId,
+            @RequestParam(defaultValue = "4") int limit
+    ){
+        return storyService.getRecentStoriesOfFollowing(memberLoginId, limit);
+    }
+
+    //나의 스토리 보기
+    //http://localhost:8080/api/story/me?memberLoginId=user1
+    @GetMapping("/me")
+    public List<StoryResponseDTO> getMyStories(@RequestParam String memberLoginId){
+        return storyService.getMyStories(memberLoginId);
+    }
+
+    //사용자가 팔로잉한 사람들의 스토리 보기
+    public List<StoryResponseDTO> getFollowingStories(@RequestParam String memberLoginId){
+        return storyService.getStoriesOfFollowing(memberLoginId);
+    }
+
+    //스토리 삭제
+    //DELETE http://localhost:8080/api/story/1
+    //Key = memberLoginId, value = loginId 값
+    //key = storyId, value = 스토리 ID
+    @DeleteMapping("/{storyId}")
+    public ResponseEntity<?> deleteMyStory(
+            @PathVariable Long storyId,
+            @RequestParam String memberLoginId
+    ) {
+        storyService.deleteStory(storyId, memberLoginId);
+        return ResponseEntity.noContent().build();
+    }
+
+    //storyId로 스토리 조회
+    //http://localhost:8080/api/story/1
+    @GetMapping("/{storyId}")
+    public StoryResponseDTO getStory(@PathVariable Long storyId) {
+        return storyService.getStoryById(storyId);
+    }
+
+    //내가 마지막으로 올린(최근에 올린) 스토리 조회
+    //http://localhost:8080/api/story/my-latest?memberLoginId=user1 -> user1이 가장 최근에 올린 이미지 반환
+    /*
+    response 예시
+ {
+    "imageUrl": "스토리이미지.jpg",
+    "authorId": 1,
+    "authorUsername": "user1",
+    "authorProfileImageUrl": null,
+    "createdAt": "2025-05-18T17:38:31.14527",
+    "expireAt": "2025-05-19T17:38:31.14527"
+}
+    * */
+
+
+    @GetMapping("/my-latest")
+    public StoryResponseDTO getMyLatestStory(@RequestParam String memberLoginId) {
+        System.out.println("memberLoginId = " + memberLoginId);
+        return storyService.getLatestStoryByMember(memberLoginId);
+    }
+
+}

--- a/src/main/java/com/project/Journey/story/dto/StoryRequestDTO.java
+++ b/src/main/java/com/project/Journey/story/dto/StoryRequestDTO.java
@@ -1,0 +1,18 @@
+package com.project.Journey.story.dto;
+
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+public class StoryRequestDTO {
+
+    @NotNull
+    private MultipartFile imageFile;
+    private LocalDateTime expireAt;
+}

--- a/src/main/java/com/project/Journey/story/dto/StoryResponseDTO.java
+++ b/src/main/java/com/project/Journey/story/dto/StoryResponseDTO.java
@@ -1,0 +1,26 @@
+package com.project.Journey.story.dto;
+
+import com.project.Journey.story.entity.Story;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class StoryResponseDTO {
+
+    private String imageUrl;
+    private Long authorId;
+    private String authorUsername;
+    private String authorProfileImageUrl;
+    private LocalDateTime createdAt;
+    private LocalDateTime expireAt;
+
+    public StoryResponseDTO(Story story){
+        this.imageUrl= story.getImageUrl();
+        this.authorId= story.getAuthor().getId();
+        this.authorUsername = story.getAuthor().getLoginId();
+        this.authorProfileImageUrl=story.getAuthor().getProfileImage();
+        this.createdAt=story.getCreatedAt();
+        this.expireAt=story.getExpireAt();
+    }
+}

--- a/src/main/java/com/project/Journey/story/entity/Story.java
+++ b/src/main/java/com/project/Journey/story/entity/Story.java
@@ -1,0 +1,37 @@
+package com.project.Journey.story.entity;
+
+import com.project.Journey.login.member.domain.Member;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class Story {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String imageUrl;
+
+    private LocalDateTime createdAt;
+
+    private LocalDateTime expireAt;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "author_id")
+    private Member author;
+
+    public Story(Member author, String imageUrl, LocalDateTime expireAt){
+        this.author=author;
+        this.imageUrl=imageUrl;
+        this.expireAt=expireAt;
+        this.createdAt=LocalDateTime.now();
+    }
+
+
+}

--- a/src/main/java/com/project/Journey/story/repository/StoryRepository.java
+++ b/src/main/java/com/project/Journey/story/repository/StoryRepository.java
@@ -1,0 +1,39 @@
+package com.project.Journey.story.repository;
+
+import com.project.Journey.login.member.domain.Member;
+import com.project.Journey.story.entity.Story;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface StoryRepository extends JpaRepository<Story, Long> {
+
+    // 기존: 전체 활성 스토리
+    @Query("SELECT s FROM Story s WHERE s.author IN :authors AND s.expireAt > :now ORDER BY s.createdAt DESC")
+    List<Story> findActiveByAuthors(
+            @Param("authors") List<Member> authors,
+            @Param("now") LocalDateTime now
+    );
+
+    // 변경: pageable 지원(최신순으로, 최대 limit)
+    List<Story> findByAuthorInAndExpireAtGreaterThanOrderByCreatedAtDesc(
+            List<Member> authors,
+            LocalDateTime now,
+            Pageable pageable
+    );
+
+    List<Story> findByAuthorOrderByCreatedAtDesc(Member author);
+
+
+    //내가 마지막으로 올린(최근에 올린) 스토리 조회
+    Optional<Story> findTop1ByAuthor_LoginIdOrderByCreatedAtDesc(@Param("loginId") String loginId);
+
+
+}

--- a/src/main/java/com/project/Journey/story/service/StoryService.java
+++ b/src/main/java/com/project/Journey/story/service/StoryService.java
@@ -1,0 +1,177 @@
+package com.project.Journey.story.service;
+
+import com.project.Journey.awss3.S3Service;
+import com.project.Journey.login.follow.entity.Follow;
+import com.project.Journey.login.follow.repository.FollowRepository;
+import com.project.Journey.login.member.domain.Member;
+import com.project.Journey.login.member.repository.MemberRepository;
+import com.project.Journey.story.dto.StoryRequestDTO;
+import com.project.Journey.story.dto.StoryResponseDTO;
+import com.project.Journey.story.entity.Story;
+import com.project.Journey.story.repository.StoryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class StoryService {
+
+    private final MemberRepository memberRepository;
+    private final FollowRepository followRepository;
+    private final StoryRepository storyRepository;
+    private final S3Service s3Service;
+
+    @Transactional
+    public void uploadStory(String memberLoginId, MultipartFile imageFile, String expireAtStr){
+        Member author = memberRepository.findByLoginId(memberLoginId)
+                .orElseThrow(()-> new IllegalArgumentException("회원을 찾을 수 없습니다."));
+
+        //스토리 이미지 업로드
+        String imageUrl = s3Service.uploadApplicationImage(imageFile);
+
+        //스토리 만료 시간을 지정(지정해주지 않으면 24시간 후에 지워짐)
+        LocalDateTime expireAt;
+        if(expireAtStr != null){
+            expireAt=LocalDateTime.parse(expireAtStr);
+        }else{
+            expireAt = LocalDateTime.now().plusHours(24);
+        }
+
+
+        Story story = new Story(author,imageUrl,expireAt);
+        storyRepository.save(story);
+    }
+
+    //내가 팔로잉한 사람들의 활성 스토리를 최신순으로 최대 limit개 가져오기
+    @Transactional(readOnly = true)
+    public List<StoryResponseDTO> getRecentStoriesOfFollowing(String memberLoginId, int limit){
+        Member me = memberRepository.findByLoginId(memberLoginId)
+                .orElseThrow(()-> new IllegalArgumentException("회원을 찾을 수 없습니다."));
+
+        //팔로잉 목록 조회
+        List<Follow> follows = followRepository.findByFollower(me);
+        List<Member> followingMembers = new ArrayList<>();
+
+        for(Follow f : follows){
+            followingMembers.add(f.getFollowing());
+        }
+
+        if(followingMembers.isEmpty()){
+            return Collections.emptyList();
+        }
+
+        Pageable pageable = PageRequest.of(0, limit);
+
+        List<Story> stories = storyRepository
+                .findByAuthorInAndExpireAtGreaterThanOrderByCreatedAtDesc(
+                        followingMembers,
+                        LocalDateTime.now(),
+                        pageable
+                );
+
+        //DTO 변환
+        List<StoryResponseDTO> responseDTOS = new ArrayList<>();
+        for(Story s : stories){
+            responseDTOS.add(new StoryResponseDTO(s));
+        }
+
+        return responseDTOS;
+    }
+
+
+
+
+
+
+
+    //내가 팔로잉한 사람들의 스토리 불러오기(최신순 x)
+    @Transactional(readOnly = true)
+    public List<StoryResponseDTO> getStoriesOfFollowing(String memberLoginId){
+        Member me = memberRepository.findByLoginId(memberLoginId)
+                .orElseThrow(()-> new IllegalArgumentException("회원을 찾을 수 없습니다."));
+
+        List<Follow> follows = followRepository.findByFollower(me);
+        List<Member> followingMembers = new ArrayList<>();
+
+        for(Follow follow : follows){
+            followingMembers.add(follow.getFollowing());
+        }
+
+        List<Story> stories = storyRepository.findActiveByAuthors(followingMembers, LocalDateTime.now());
+
+        List<StoryResponseDTO> result = new ArrayList<>();
+        for(Story story : stories){
+            result.add(new StoryResponseDTO(story));
+        }
+        return result;
+    }
+
+
+    //나의 스토리 불러오기
+    @Transactional(readOnly = true)
+    public List<StoryResponseDTO> getMyStories(String memberLoginId){
+        Member me = memberRepository.findByLoginId(memberLoginId)
+                .orElseThrow(() -> new IllegalArgumentException("회원을 찾을 수 없습니다."));
+
+        List<Story> myStories = storyRepository.findByAuthorOrderByCreatedAtDesc(me);
+
+        List<StoryResponseDTO> responseDTOList = new ArrayList<>();
+        for(Story story : myStories){
+            responseDTOList.add(new StoryResponseDTO(story));
+        }
+
+        return responseDTOList;
+    }
+
+
+    //스토리 삭제
+    @Transactional
+    public void deleteStory(Long storyId, String memberLoginId){
+
+        //1. 삭제할 스토리 조회
+        Story story = storyRepository.findById(storyId)
+                .orElseThrow(()-> new IllegalArgumentException("스토리를 찾을 수 없습니다."));
+
+        //2. 작성자 본인인지 검증
+        if(!story.getAuthor().getLoginId().equals(memberLoginId)){
+            throw new SecurityException("본인이 작성한 스토리만 삭제할 수 있습니다.");
+        }
+
+        //3. 스토리 이미지 S3에서도 삭제
+        String imageUrl = story.getImageUrl();
+        if(imageUrl != null && !imageUrl.isEmpty()){
+            s3Service.deleteS3Image(imageUrl);
+        }
+
+        //4. DB에서 스토리 삭제
+        storyRepository.delete(story);
+    }
+
+
+    //스토리 ID로 특정 스토리 조회하기
+    @Transactional(readOnly = true)
+    public StoryResponseDTO getStoryById(Long storyId) {
+        Story story = storyRepository.findById(storyId)
+                .orElseThrow(() -> new IllegalArgumentException("스토리를 찾을 수 없습니다."));
+
+        return new StoryResponseDTO(story);
+    }
+
+    //내가 마지막으로 올린(최근에 올린) 스토리 조회하기
+    @Transactional(readOnly = true)
+    public StoryResponseDTO getLatestStoryByMember(String memberLoginId) {
+        Story story = storyRepository.findTop1ByAuthor_LoginIdOrderByCreatedAtDesc(memberLoginId)
+                .orElseThrow(() -> new IllegalArgumentException("스토리가 존재하지 않습니다."));
+        return new StoryResponseDTO(story);
+    }
+
+}


### PR DESCRIPTION
## 팔로우(팔로잉) 기능, 스토리 기능 개발

### 💡 요약
✅ 팔로우(팔로잉) 기능 개발
- 사용자 간 팔로우 및 언팔로우 기능 구현
- 팔로잉 중인 사용자 목록 조회 기능 구현
- 유저를 팔로우한 사용자 목록 조회 기능 구현

✅ 스토리 기능 개발
- 스토리 업로드 기능 구현
- 팔로잉한 사람들의 스토리 중 최신 스토리 N개 조회 기능 구현
- 나의 스토리 보기 기능 구현
- 스토리 삭제 기능 구현
- storyId로 스토리 조회 기능 구현
- 내가 올린 스토리 보기 기능 구현(가장 최신에 업데이트 한 스토리)


## 🔨 구현 내용

### 1. 팔로우(팔로잉) 기능 개발(#39)
- `POST /api/follow`: 사용자가 특정 유저를 팔로우
→ 쿼리 파라미터로 사용자의 loginId 입력
→ `FollowRequestDTO`를 사용해 팔로우 할 타겟 사용자 loginId를 JSON으로 전달
→ API 요청 예시 : POST http://localhost:8080/api/follow?myLoginId=user1

- `DELETE /api/unfollow`: 사용자가 특정 유저를 언팔로우
→ 쿼리 파라미터로 사용자의 loginId와 언팔로우 할 사람의 loginId를 받아온다

- `GET /api/follow/following?memberLoginId=xxx`: loginId가 xxx인 사용자의 팔로잉 목록 조회
- `GET /api/follow/followers?memberLoginId=xxx`: loginId가 xxx인 사용자의 팔로워 목록 조회



### 2. 스토리 기능 개발(#40)
- `POST /api/story`: 사용자 스토리 업로드 (multipart/form-data로 이미지 전송)
  - 요청 필드: `memberLoginId`(String), `imageFile`(MultipartFile), `expireAt`(옵션)
- `GET /api/story/following/recent?memberLoginId=xxx&limit=4`: 팔로우 중인 사용자들의 스토리 중 최신 limit개를 지정하여 조회
- `GET /api/story/my-latest?memberLoginId=xxx`: 사용자의 가장 최신 스토리 1개 조회
- `GET /api/story/{storyId}` : storyId로 스토리 조회
- `DELETE /api/story/{storyId}` : 스토리 삭제

→ 업로드된 이미지는 S3에 저장되며, DB에는 `id`, `imageUrl`, `createdAt`, `expireAt`,  `author_id`정보가 함께 저장

## 테스트
- Postman을 통해 multipart/form-data 및 JSON 요청 테스트 완료

## ⚠️ 참고사항
피그마에 API에 대한 설명을 적어놓았습니다! Swagger로 API 명세서도 업데이트 해놓겠습니다!
