### PR TITLE
feat: 프로필 이미지·닉네임 조회 API 구현(#53)

### DIFF
--- a/src/main/java/com/project/Journey/board/controller/PostController.java
+++ b/src/main/java/com/project/Journey/board/controller/PostController.java
@@ -501,7 +501,7 @@ public class PostController {
             @RequestParam(defaultValue = "1") int page,
 
             @Parameter(description = "페이지 당 가져올 게시글 수")
-            @RequestParam(defaultValue = "6") int size
+            @RequestParam(defaultValue = "12") int size
     ) {
         request.setPage(page);           // 필수: request 내부에 페이지 정보 세팅
         request.setRecordSize(size);    // 필수: 한 페이지 크기 세팅

--- a/src/main/java/com/project/Journey/login/member/controller/ProfileController.java
+++ b/src/main/java/com/project/Journey/login/member/controller/ProfileController.java
@@ -1,9 +1,6 @@
 package com.project.Journey.login.member.controller;
 
-import com.project.Journey.login.member.dto.ProfileResponse;
-import com.project.Journey.login.member.dto.ProfileUpdateRequest;
-import com.project.Journey.login.member.dto.TravelPlanRequest;
-import com.project.Journey.login.member.dto.TravelPlanResponse;
+import com.project.Journey.login.member.dto.*;
 import com.project.Journey.login.member.service.ProfileService;
 import com.project.Journey.login.member.service.TravelPlanService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -82,6 +79,21 @@ public class ProfileController {
     public ResponseEntity<?> deletePlan(@PathVariable Long planId) {
         planService.deletePlan(planId);
         return ResponseEntity.ok("삭제 완료");
+    }
+
+    @Operation(
+            summary = "프로필 이미지와 닉네임 조회",
+            description = "댓글, 목록 그리고 헤더에 사용할 가벼운 전용 API입니다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공",
+                    content = @Content(schema = @Schema(implementation = ProfileImageResponse.class))),
+            @ApiResponse(responseCode = "400", description = "회원 없음",
+                    content = @Content(schema = @Schema(example = "회원 없음")))
+    })
+    @GetMapping("/{id}/profile-image")
+    public ResponseEntity<ProfileImageResponse> getProfileImage(@PathVariable Long id) {
+        return ResponseEntity.ok(profileService.getProfileImage(id));
     }
 
 }

--- a/src/main/java/com/project/Journey/login/member/dto/ProfileImageResponse.java
+++ b/src/main/java/com/project/Journey/login/member/dto/ProfileImageResponse.java
@@ -1,0 +1,22 @@
+package com.project.Journey.login.member.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.*;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "닉네임과 프로필 이미지 전용 응답 DTO")
+public class ProfileImageResponse {
+
+    @Schema(description = "회원 PK", example = "7")
+    private Long memberId;
+
+    @Schema(description = "닉네임(없으면 loginId)", example = "모아찌")
+    private String nickname;
+
+    @Schema(description = "프로필 이미지 URL(없으면 기본이미지)", example = "https://our-s3-bucket.com/imgaes/profile7.png")
+    private String profileImage;
+}

--- a/src/main/java/com/project/Journey/login/member/service/ProfileService.java
+++ b/src/main/java/com/project/Journey/login/member/service/ProfileService.java
@@ -2,6 +2,7 @@ package com.project.Journey.login.member.service;
 
 import com.project.Journey.login.member.domain.Member;
 import com.project.Journey.login.member.domain.MemberTag;
+import com.project.Journey.login.member.dto.ProfileImageResponse;
 import com.project.Journey.login.member.dto.ProfileResponse;
 import com.project.Journey.login.member.dto.ProfileUpdateRequest;
 import com.project.Journey.login.member.repository.MemberRepository;
@@ -65,6 +66,17 @@ public class ProfileService {
                 tagRepo.save(new MemberTag(m, t));
             });
         }
+    }
+
+    public ProfileImageResponse getProfileImage(Long memberId) {
+        Member member = memberRepo.findById(memberId)
+                .orElseThrow(() -> new IllegalArgumentException("회원 없음"));
+
+        return ProfileImageResponse.builder()
+                .memberId(member.getId())
+                .nickname(member.getDisplayName())
+                .profileImage(member.getProfileImage())
+                .build();
     }
 
 }


### PR DESCRIPTION
# ✅ 프로필 이미지 전용 조회 API 추가
댓글, 헤더, 목록 등에 활용할 프로필 이미지 전용 조회 API 추가했습니다.

## 🛠️ 작업내용
- 프로필 이미지만 필요한 상황(댓글, 게시판 목록, 헤더 등)에서 전체 프로필 데이터를 내려주는 기존 API는 응답이 과도하게 큼
- 이를 해결하기 위해 닉네임과 프로필 이미지 정보만 내려주는 전용 API를 별도로 구현
- 요청 URL: `GET /api/members/{id}/profile-image`
- 응답 예시:
  ```json
  {
    "memberId": 7,
    "nickname": "모아찌",
    "profileImage": "https://…/profile7.png"
  }

