### PR TITLE
[Refactor] Post 엔티티를 Member 엔티티와 연관관계를 매핑, 커뮤니티 게시글 목록 조회 API 구현 (페이징) 을 위해 리펙토링(#52)

### DIFF
--- a/src/main/java/com/project/Journey/board/controller/PostController.java
+++ b/src/main/java/com/project/Journey/board/controller/PostController.java
@@ -45,7 +45,7 @@ public class PostController {
             participants 필수
             
             post : {
-            "userId": "미국여행자3", -> String
+            "memberId": 1, -> Long
             "country": "미국", -> String
             "title": "미국 뉴욕으로~~~", -> String
             "startDate": "2025-03-23", -> LocalDateTime
@@ -97,7 +97,7 @@ public class PostController {
             [
                 {
                     "postId": null,
-                        "user_id": "user1",
+                        "nickname": "user1",
                         "title": "유럽 여행 같이 가실 분 구합니다!",
                         "content": "유럽 여행 같이가요~~!",
                         "destination": "프랑스",
@@ -170,7 +170,7 @@ public class PostController {
             key : post, value: json( /api/posts/getIncrementView/{postId}의 response객체)
              {
                 "postId": 8,
-                "user_id": "여행자",
+                "nickname": "여행자",
                 "title": "캘리포니아 같이 가실 분 구해요!!! - 게시글 수정", -> 수정 가능
                 "content": "이번 방학때 캘리포니아에 가게 됐는데 혼자 여행가게 되었습니다!\\n같이 동행하실 분 구해요", -> 수정 가능
                 "destination": "미국 캘리포니아", -> 수정 가능
@@ -234,7 +234,7 @@ public class PostController {
             @ApiResponse(responseCode = "500", description = "서버에서 오류가 발생했습니다.")
     })
     @GetMapping("api/posts/top-views")
-    public List<Post> getTopViewedPosts(){
+    public List<PostDTO> getTopViewedPosts(){
         try{
             return postService.getPostsByViewCount();
         }catch (Exception e){
@@ -253,7 +253,7 @@ public class PostController {
             response :
             {
                "postId": 21,
-                   "user_id": "미국여행자2",
+                   "nickname": "미국여행자2",
                    "title": "미국으로 떠나요2",
                    "content": "미국 뉴욕여행같이해요~~!!!",
                    "destination": "미국",
@@ -292,13 +292,13 @@ public class PostController {
 
     //user_id로 게시글 조회
     @Operation(summary = "사용자 게시글 조회", description = """
-            특정 사용자의 user_id로 게시글을 조회합니다.
+            특정 사용자의 memberId로 게시글을 조회합니다.
             
             API 요청 예시 : http://localhost:8080/api/posts/get/user_id/user1234
             
             response : [
             {
-                    "user_id": "user1234",
+                    "nickname": "user1234",
                     "title": "제주도 여행",
                     "content": "제주도로 떠나요!",
                     "destination": "한국",
@@ -321,13 +321,13 @@ public class PostController {
             @ApiResponse(responseCode = "200", description = "해당 사용자의 게시글 목록이 성공적으로 반환되었습니다."),
             @ApiResponse(responseCode = "404", description = "해당 사용자의 게시글을 찾을 수 없습니다.")
     })
-    @GetMapping("api/posts/get/user_id/{user_id}")
-    public List<PostDTO> getPostsByUser_id( @Parameter(description = "게시글을 조회할 사용자의 user_id", required = true, example = "user123") @PathVariable String user_id){
+    @GetMapping("api/posts/get/memberId/{memberId}")
+    public List<PostDTO> getPostsByMemberId( @Parameter(description = "게시글을 조회할 사용자의 memberId", required = true, example = "1") @PathVariable Long memberId){
         try{
-            List<PostDTO> posts = postService.getPostsByUserId(user_id);
+            List<PostDTO> posts = postService.getPostsByMemberId(memberId);
             return posts;
         } catch (Exception e){
-            throw new PostException("해당 user_id의 게시글이 존재하지 않습니다.",HttpStatus.NOT_FOUND);
+            throw new PostException("해당 memberId의 게시글이 존재하지 않습니다.",HttpStatus.NOT_FOUND);
         }
     }
 
@@ -351,7 +351,7 @@ public class PostController {
             response :
             [
              {
-                    "user_id": "user1234",
+                    "memberId": "user1234",
                     "title": "제주도 여행",
                     "content": "제주도로 떠나요!",
                     "destination": "한국",
@@ -366,7 +366,7 @@ public class PostController {
                     "country": "한국"
                 },
                 {
-                    "user_id": "user1234",
+                    "memberId": "user1234",
                     "title": "부산 여행",
                     "content": "부산으로 떠나요!",
                     "destination": "한국",

--- a/src/main/java/com/project/Journey/board/dto/PostDTO.java
+++ b/src/main/java/com/project/Journey/board/dto/PostDTO.java
@@ -14,7 +14,7 @@ import java.util.List;
 public class PostDTO {
 
     private Long postId; //게시글 id
-    private String user_id; //유저 아이디
+    private String nickname; //닉네임
     private String title; //제목
     private String content;//내용
     private String destination; //장소

--- a/src/main/java/com/project/Journey/board/dto/PostRequestDTO.java
+++ b/src/main/java/com/project/Journey/board/dto/PostRequestDTO.java
@@ -15,7 +15,7 @@ import java.util.List;
 public class PostRequestDTO { //동행자 모집 게시글을 생성/수정할 때 사용하는 DTO
 
 
-    private String userId; //사용자 아이디
+    private Long memberId;
     private String country; //게시판 선택(국가)
     private String title; // 제목
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")

--- a/src/main/java/com/project/Journey/board/dto/PostSearchRequest.java
+++ b/src/main/java/com/project/Journey/board/dto/PostSearchRequest.java
@@ -10,7 +10,7 @@ import java.time.LocalDate;
 public class PostSearchRequest extends PostSearchDTO{
     private String country;
     private String title;
-    private String user_id;
+    private String nickname;
     private LocalDate startDate;
     private LocalDate endDate;
     private Long postId; // 게시글 번호로 검색

--- a/src/main/java/com/project/Journey/board/entity/Post.java
+++ b/src/main/java/com/project/Journey/board/entity/Post.java
@@ -1,6 +1,8 @@
 package com.project.Journey.board.entity;
 
 import com.project.Journey.community.entity.CommunityImage;
+import com.project.Journey.login.member.domain.Member;
+
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -22,10 +24,9 @@ public class Post {
     @Column(name = "post_id")
     private Long postId;
 
-    //@ManyToOne
-    //@JoinColumn(name = "user_id", nullable = false)
-    @Column(name = "user_id")
-    private String user_id;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
 
     @Column(nullable = false, length = 100)
     private String title;
@@ -65,11 +66,6 @@ public class Post {
     //@Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private String country;
-
-
-    //프로필 이미지 url
-    @Column(nullable = true)
-    private String profileImageUrl;
 
     //첨부파일 이미지 (여러 개)
     @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)

--- a/src/main/java/com/project/Journey/board/paging/PostSpecification.java
+++ b/src/main/java/com/project/Journey/board/paging/PostSpecification.java
@@ -19,8 +19,8 @@ public class PostSpecification {
                 predicates.add(builder.like(root.get("title"), "%" + request.getTitle() + "%"));
             }
 
-            if (request.getUser_id() != null && !request.getUser_id().isEmpty()) {
-                predicates.add(builder.equal(root.get("user_id"), request.getUser_id()));
+            if (request.getNickname() != null && !request.getNickname().isEmpty()) {
+                predicates.add(builder.equal(root.get("user_id"), request.getNickname()));
             }
 
             if (request.getCountry() != null && !request.getCountry().isEmpty()) {

--- a/src/main/java/com/project/Journey/board/repository/PostRepository.java
+++ b/src/main/java/com/project/Journey/board/repository/PostRepository.java
@@ -22,8 +22,8 @@ public interface PostRepository extends JpaRepository<Post, Long>, JpaSpecificat
     @Query("UPDATE Post p SET p.view_count = :increment WHERE p.postId = :postId")
     void incrementViewCount(@Param("postId") Long postId, @Param("increment") int increment);
 
-    @Query("SELECT p FROM Post p WHERE p.user_id = :user_id")
-    List<Post> findPostsByUserId(@Param("user_id") String user_id);
+    @Query("SELECT p FROM Post p WHERE p.member.id = :memberId")
+    List<Post> findPostsByMemberId(@Param("memberId") Long memberId);
 
     //페이지네이션 기능 개발
     Page<Post> findAll(Pageable pageable);

--- a/src/main/java/com/project/Journey/board/service/PostService.java
+++ b/src/main/java/com/project/Journey/board/service/PostService.java
@@ -11,6 +11,9 @@ import com.project.Journey.board.repository.PostImageRepository;
 import com.project.Journey.board.repository.PostRepository;
 import com.project.Journey.community.dto.CommunityMainHotPostDTO;
 import com.project.Journey.board.paging.Pagination;
+import com.project.Journey.login.member.domain.Member;
+import com.project.Journey.login.member.repository.MemberRepository;
+
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -42,18 +45,29 @@ public class PostService {
     @Autowired
     private final RedisTemplate<String, Object> redisTemplate;
 
+    private final MemberRepository memberRepository;
 
-    public PostService(PostRepository postRepository, S3Service s3Service, PostImageRepository postImageRepository, @Qualifier("jsonRedisTemplate") RedisTemplate<String, Object> redisTemplate) {
+
+    public PostService(PostRepository postRepository, S3Service s3Service, PostImageRepository postImageRepository, @Qualifier("jsonRedisTemplate") RedisTemplate<String, Object> redisTemplate,
+		MemberRepository memberRepository) {
         this.postRepository = postRepository;
         this.s3Service = s3Service;
         this.postImageRepository = postImageRepository;
         this.redisTemplate = redisTemplate;
-    }
+		this.memberRepository = memberRepository;
+	}
 
     private static final String VIEW_COUNT_KEY = "view_count:";
 
     //게시글 저장
     public Long savePost(PostRequestDTO postRequestDTO, MultipartFile coverImage, List<MultipartFile> images) {
+
+
+        //1. 작성자 Member 조회
+        Member member = memberRepository.findById(postRequestDTO.getMemberId())
+            .orElseThrow(() -> new IllegalArgumentException("해당 유저가 존재하지 않습니다."));
+
+
         // 1️. S3에 커버 이미지 업로드 후 URL 저장
         String coverImageUrl = null;
         if (coverImage != null && !coverImage.isEmpty()) {
@@ -62,7 +76,7 @@ public class PostService {
 
         // 2. 게시글 객체 생성
         Post post = Post.builder()
-                .user_id(postRequestDTO.getUserId())
+                .member(member)
                 .country(postRequestDTO.getCountry())
                 .title(postRequestDTO.getTitle())
                 .startDate(postRequestDTO.getStartDate())
@@ -75,7 +89,6 @@ public class PostService {
                 .content(postRequestDTO.getContent())
                 .createdAt(LocalDateTime.now())
                 .updated_at(LocalDateTime.now())
-                .profileImageUrl("") //프로필 이미지
                 .build();
 
         // 3️. 게시글을 먼저 저장 (DB에 저장)
@@ -108,6 +121,7 @@ public class PostService {
 
         for(Post post : postList){
             PostDTO postDto = PostDTO.builder()
+                    .postId(post.getPostId())
                     .title(post.getTitle())
                     .content(post.getContent())
                     .destination(post.getDestination())
@@ -118,7 +132,8 @@ public class PostService {
                     .comment_count(post.getComment_count())
                     .created_at(post.getCreatedAt())
                     .updated_at(post.getUpdated_at())
-                    .user_id(post.getUser_id())
+                    .nickname(post.getMember().getNickname())
+                    .profileImageUrl(post.getMember().getProfileImage())
                     .coverImageUrl(post.getCoverImageUrl())// image url
                     .country(post.getCountry()) //국가
                     .build();
@@ -196,40 +211,6 @@ public class PostService {
     }
 
 
-
-
-
-
-    /*
-    @Transactional
-    public void updatePostById(Long postId, PostDTO postDTO){
-        Post post = postRepository.findById(postId)
-                .orElseThrow(() -> new IllegalArgumentException("해당 post_id의 게시글이 없습니다"));
-        post.updateTitle(postDTO.getTitle());
-        post.updateContent(postDTO.getContent());
-        post.updateDestination(postDTO.getDestination());
-        post.updateMaxParticipants(postDTO.getMax_participants());
-        post.updateStartDate(postDTO.getStart_date());
-        post.updateEndDate(postDTO.getEnd_date());
-        post.updateUpdateTime(postDTO.getUpdated_at());
-        post.updateCoverImageUrl(postDTO.getCoverImageUrl()); //커버 image url
-        post.updateCountry(postDTO.getCountry());
-
-    }
-*/
-
-
-
-
-
-
-
-
-
-
-
-
-
     // post_id로 게시글 조회
     /*
     public PostDTO getPostById(Long postId) {
@@ -255,12 +236,6 @@ public class PostService {
 
      */
     // 게시글 삭제
-    /*
-    @Transactional
-    public void deletePost(Long postId) {
-        postRepository.deleteById(postId);
-    }
-    */
     @Transactional
     public void deletePost(Long postId){
         Post post = postRepository.findById(postId)
@@ -287,12 +262,8 @@ public class PostService {
         postRepository.delete(post);
     }
 
-
-
-
-
     //조회 수가 높은 순서대로 조회(핫 게시글)
-    public List<Post> getPostsByViewCount(){
+    public List<PostDTO> getPostsByViewCount(){
         List<Post> hotPosts = postRepository.findAll();
         hotPosts.sort(new Comparator<Post>() {
             @Override
@@ -300,7 +271,30 @@ public class PostService {
                 return o2.getView_count() - o1.getView_count();
             }
         });
-        return hotPosts;
+        return hotPosts.stream()
+            .map(post -> PostDTO.builder()
+                .postId(post.getPostId())
+                .nickname(post.getMember().getNickname())
+                .title(post.getTitle())
+                .content(post.getContent())
+                .destination(post.getDestination())
+                .start_date(post.getStartDate())
+                .end_date(post.getEndDate())
+                .max_participants(post.getMax_participants())
+                .view_count(post.getView_count())
+                .comment_count(post.getComment_count())
+                .created_at(post.getCreatedAt())
+                .updated_at(post.getUpdated_at())
+                .coverImageUrl(post.getCoverImageUrl())
+                .profileImageUrl(post.getMember().getProfileImage()) // Member에 해당 필드가 있다고 가정
+                .country(post.getCountry())
+                .imageUrls(post.getImages() != null ?
+                    post.getImages().stream()
+                        .map(PostImage::getPostImageUrl)
+                        .collect(Collectors.toList()) :
+                    List.of())
+                .build())
+            .collect(Collectors.toList());
     }
 
     //게시글 조회 - 이미지 불러오기 기능 추가
@@ -337,7 +331,7 @@ public class PostService {
 
         PostDTO postDTO = new PostDTO(
                 post.getPostId(),
-                post.getUser_id(),
+                post.getMember().getNickname(),
                 post.getTitle(),
                 post.getContent(),
                 post.getDestination(),
@@ -349,7 +343,7 @@ public class PostService {
                 post.getCreatedAt(),
                 post.getUpdated_at(),
                 post.getCoverImageUrl(),
-                post.getProfileImageUrl(),
+                post.getMember().getProfileImage(),
                 post.getCountry(),
                 images
         );
@@ -386,12 +380,13 @@ public class PostService {
     }
 
     // user_id로 게시글 조회
-    public List<PostDTO> getPostsByUserId(String user_id) {
-        List<Post> list =  postRepository.findPostsByUserId(user_id);
-        List<PostDTO> postDtoListByUserId = new ArrayList<>();
+    public List<PostDTO> getPostsByMemberId(Long memberId) {
+        List<Post> list =  postRepository.findPostsByMemberId(memberId);
+        List<PostDTO> postDtoListByMemberId= new ArrayList<>();
 
         for(Post post : list){
             PostDTO postDto = PostDTO.builder()
+                    .postId(post.getPostId())
                     .title(post.getTitle())
                     .content(post.getContent())
                     .destination(post.getDestination())
@@ -402,13 +397,14 @@ public class PostService {
                     .comment_count(post.getComment_count())
                     .created_at(post.getCreatedAt())
                     .updated_at(post.getUpdated_at())
-                    .user_id(post.getUser_id())
+                    .nickname(post.getMember().getNickname())
+                    .profileImageUrl(post.getMember().getProfileImage())
                     .coverImageUrl(post.getCoverImageUrl())
                     .country(post.getCountry())
                     .build();
-            postDtoListByUserId.add(postDto);
+            postDtoListByMemberId.add(postDto);
         }
-        return postDtoListByUserId;
+        return postDtoListByMemberId;
     }
 
 
@@ -432,7 +428,8 @@ public class PostService {
                     .comment_count(post.getComment_count())
                     .created_at(post.getCreatedAt())
                     .updated_at(post.getUpdated_at())
-                    .user_id(post.getUser_id())
+                    .nickname(post.getMember().getNickname())
+                    .profileImageUrl(post.getMember().getProfileImage())
                     .coverImageUrl(post.getCoverImageUrl())
                     .country(post.getCountry())
                     .build();
@@ -458,7 +455,8 @@ public class PostService {
                     .comment_count(post.getComment_count())
                     .created_at(post.getCreatedAt())
                     .updated_at(post.getUpdated_at())
-                    .user_id(post.getUser_id())
+                    .nickname(post.getMember().getNickname())
+                    .profileImageUrl(post.getMember().getProfileImage())
                     .coverImageUrl(post.getCoverImageUrl())
                     .country(post.getCountry())
                     .build();

--- a/src/main/java/com/project/Journey/community/controller/CommunityController.java
+++ b/src/main/java/com/project/Journey/community/controller/CommunityController.java
@@ -281,7 +281,9 @@ response 예시 :
            
             API 호출 예시: 
                        
-            * API 테스트 default(country는 입력 필수) : http://localhost:8080/api/community/search?country=국내
+            * API 테스트 default: http://localhost:8080/api/community/search?country=국내
+            
+            * 전체 게시글 검색 : http://localhost:8080/api/community/search
             
             * 게시글 제목으로 검색 : http://localhost:8080/api/community/search?country=국내&title=맛집
             
@@ -382,9 +384,9 @@ response 예시 :
             """)
     @GetMapping("/api/community/search")
     public CommunitySearchResponseDTO searchPosts(
-
-            @Parameter(description = "국가", required = true)
-            @RequestParam String country,
+            //기본은 country 값을 지정(default), 커뮤니티 게시글 전체를 조회하고 싶으면 쿼리파라미터 없이 호출
+            @Parameter(description = "국가", required = false)
+            @RequestParam(required = false) String country,
 
             @Parameter(description = "게시글 번호", required = false)
             @RequestParam(required = false) Long number,


### PR DESCRIPTION
## 작업 내용
1. Post 엔티티의 user_id 필드를 사용하는 대신 **Member 엔티티와 연관관계를 매핑**해주었습니다.
2. 페이징으로 **커뮤니티 게시글 전체를 조회하는 기능을 구현하기 위해 코드를 리팩토링** 해주었고 이에 따라 피그마와 API 명세서를 업데이트 해주었습니다.(#52)
 
* 기존의 코드 :  

```
 @Parameter(description = "국가", required = true)
            @RequestParam String country,
``` 
에서
```
            @Parameter(description = "국가", required = false)
            @RequestParam(required = false) String country,
```
로 수정하였습니다!

전체 게시글 검색 예시 : `GET http://localhost:8080/api/community/search`

전체 게시글을 검색하고 싶으면 쿼리 파라미터에 값을 넣을 필요 없이 예시처럼 호출해주시면 됩니다!

## 기타사항
연관관계를 매핑해주면서 DB의 `post_images`, `posts`, `comment` 테이블을 drop 해주어야 합니다! PR 확인해주시면 RDS에서 테이블 삭제하고 merge하겠습니다!!
