### PR TITLE
CommunityResponseDTO에 loginId 추가 및 조회 API 반영 (#62)

### DIFF
--- a/src/main/java/com/project/Journey/community/controller/CommunityController.java
+++ b/src/main/java/com/project/Journey/community/controller/CommunityController.java
@@ -86,6 +86,7 @@ public class CommunityController {
     response 예시 :
     
             response : {
+                "loginID": "traveler33",
                 "nickname": "구름",
                 "country": "국내",
                 "title": "요즘 제주도 날씨는 어떤가요?",

--- a/src/main/java/com/project/Journey/community/dto/CommunityResponseDTO.java
+++ b/src/main/java/com/project/Journey/community/dto/CommunityResponseDTO.java
@@ -13,15 +13,16 @@ import java.util.List;
 @Builder
 public class CommunityResponseDTO {
 
-    private Long CommunityPostId;
+    private Long communityPostId;
+    private String loginId;
     private String nickname;
     private String country;
     private String title;
     private String content;
-    private int view_count;
-    private int comment_count;
-    private LocalDateTime created_at;
-    private LocalDateTime updated_at;
+    private int viewCount;
+    private int commentCount;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
     private String profileImageUrl;
     private List<String> imageUrls;
 

--- a/src/main/java/com/project/Journey/community/service/CommunityService.java
+++ b/src/main/java/com/project/Journey/community/service/CommunityService.java
@@ -96,30 +96,26 @@ public class CommunityService {
                 .orElseThrow(() -> new EntityNotFoundException("게시글을 찾을 수 없습니다."));
 
         community.setViewCount(community.getViewCount()+1);
-        communityRepository.save(community);
 
-        List<CommunityImage> communityImages = community.getImages();
-        List<String> images = new ArrayList<>();
-        for(CommunityImage communityImage : communityImages){
-            images.add(communityImage.getImageUrl());
-        }
+        List<String> imageUrls = community.getImages()
+                .stream()
+                .map(CommunityImage::getImageUrl)
+                .toList();
 
-        CommunityResponseDTO communityResponseDTO
-                = new CommunityResponseDTO(
-                community.getCommunityPostId(),
-                community.getMember().getNickname(),
-                community.getCountry(),
-                community.getTitle(),
-                community.getContent(),
-                community.getViewCount(),
-                community.getComment_count(),
-                community.getCreatedAt(),
-                community.getUpdatedAt(),
-                community.getMember().getProfileImage(),
-                images
-
-        );
-        return communityResponseDTO;
+        return CommunityResponseDTO.builder()
+                .loginId(community.getMember().getLoginId())
+                .communityPostId(community.getCommunityPostId())
+                .nickname(community.getMember().getNickname())
+                .country(community.getCountry())
+                .title(community.getTitle())
+                .content(community.getContent())
+                .viewCount(community.getViewCount())
+                .commentCount(community.getComment_count())
+                .createdAt(community.getCreatedAt())
+                .updatedAt(community.getUpdatedAt())
+                .profileImageUrl(community.getMember().getProfileImage())
+                .imageUrls(imageUrls)
+                .build();
     }
 
 


### PR DESCRIPTION
## 📌 주요 변경 사항
- 커뮤니티 게시글 단건 조회(GET /api/community/getPostByPostId/{id}) 응답에 로그인한 사용자의 loginId를 포함하도록 수정
- 응답을 받은 프론트에서는 store에 저장된 로그인 ID와 게시글 작성자 정보를 직접 비교하여 UI 제어 가능

## 🛠️ 변경 내역
- CommunityResponseDTO
  - loginId 필드 추가: 현재 로그인한 사용자의 ID (세션 기준)

- CommunityService.getPostByCommunityPostId(...)
  - 게시글 조회 시 작성자 loginId를 DTO.loginId로 전달

## 비고
- 프론트에서는 authStore.user.loginId와 post.nickname(또는 응답에 포함된 작성자 ID)로 비교하여 "내 글인지" 여부 판단 가능

