### PR TITLE
대댓글 목록 조회 및 댓글에 자식 댓글 포함 기능 추가 (#66)

### DIFF
--- a/src/main/java/com/project/Journey/community/comment/dto/CommunityCommentResponseDTO.java
+++ b/src/main/java/com/project/Journey/community/comment/dto/CommunityCommentResponseDTO.java
@@ -1,6 +1,8 @@
 package com.project.Journey.community.comment.dto;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.project.Journey.community.comment.entity.CommunityComment;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -10,6 +12,7 @@ import java.util.stream.Collectors;
 
 @Getter
 @Builder(toBuilder = true)
+@AllArgsConstructor
 public class CommunityCommentResponseDTO {
 
     private Long commentId;
@@ -21,7 +24,9 @@ public class CommunityCommentResponseDTO {
     private Long parentCommentId;
     private int  replyCount;
     private boolean isActive;
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss", timezone = "Asia/Seoul")
     private LocalDateTime createdAt;
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss", timezone = "Asia/Seoul")
     private LocalDateTime updatedAt;
 
     public static CommunityCommentResponseDTO from(CommunityComment c) {
@@ -41,6 +46,31 @@ public class CommunityCommentResponseDTO {
                 .build();
     }
 
+    @Builder.Default
+    private List<CommunityCommentResponseDTO> replies = List.of();
+
+    public static CommunityCommentResponseDTO of(CommunityComment c,
+                                                 List<CommunityCommentResponseDTO> replies) {
+
+        return CommunityCommentResponseDTO.builder()
+                .commentId(c.getCommentId())
+                .communityId(c.getCommunity().getCommunityPostId())
+                .memberId(c.getMember().getId())
+                .displayName(c.getMember().getDisplayName())
+                .profileImage(c.getMember().getProfileImage())
+                .content(c.getContent())
+                .parentCommentId(c.getParentComment() != null ? c.getParentComment().getCommentId() : null)
+                .isActive(c.isActive())
+                .createdAt(c.getCreatedAt())
+                .updatedAt(c.getUpdatedAt())
+                .replies(replies)
+                .build();
+    }
+
+    public static CommunityCommentResponseDTO of(CommunityComment c) {
+        return of(c, List.of());
+    }
+
     public static CommunityCommentResponseDTO withReplies(CommunityComment root,
                                                           List<CommunityComment> replies) {
         return CommunityCommentResponseDTO.from(root).toBuilder()
@@ -48,7 +78,6 @@ public class CommunityCommentResponseDTO {
                 .build();
     }
 
-    /* 유틸: List<CommunityComment> → List<DTO> */
     public static List<CommunityCommentResponseDTO> listOf(List<CommunityComment> list) {
         return list.stream().map(CommunityCommentResponseDTO::from).collect(Collectors.toList());
     }

--- a/src/main/java/com/project/Journey/community/comment/service/CommunityCommentService.java
+++ b/src/main/java/com/project/Journey/community/comment/service/CommunityCommentService.java
@@ -58,23 +58,36 @@ public class CommunityCommentService {
         Community community = communityRepo.findById(communityId)
                 .orElseThrow(() -> new IllegalArgumentException("커뮤니티 글이 없습니다"));
 
-        return commentRepo
-                .findByCommunityAndParentCommentIsNullAndIsActiveTrueOrderByCreatedAtAsc(community)
+        List<CommunityComment> roots =
+                commentRepo.findByCommunityAndParentCommentIsNullAndIsActiveTrueOrderByCreatedAtAsc(community);
+
+        return roots.stream()
+                .map(this::toDtoWithReplies)
+                .toList();
+    }
+
+    private CommunityCommentResponseDTO toDtoWithReplies(CommunityComment root) {
+
+        List<CommunityCommentResponseDTO> children = commentRepo
+                .findByParentCommentAndIsActiveTrueOrderByCreatedAtAsc(root)
                 .stream()
-                .map(CommunityCommentResponseDTO::from)
-                .collect(Collectors.toList());
+                .map(CommunityCommentResponseDTO::of)
+                .toList();
+
+        return CommunityCommentResponseDTO.of(root, children);
     }
 
     @Transactional(readOnly = true)
     public List<CommunityCommentResponseDTO> getReplies(Long parentId) {
+
         CommunityComment parent = commentRepo.findById(parentId)
                 .orElseThrow(() -> new IllegalArgumentException("댓글이 없습니다"));
 
         return commentRepo
                 .findByParentCommentAndIsActiveTrueOrderByCreatedAtAsc(parent)
                 .stream()
-                .map(CommunityCommentResponseDTO::from)
-                .collect(Collectors.toList());
+                .map(CommunityCommentResponseDTO::of)
+                .toList();
     }
 
     public CommunityCommentResponseDTO updateComment(Long id, String content) {


### PR DESCRIPTION
### 📌 주요 변경 사항

1. `CommunityCommentResponseDTO`에 `replies` 필드 추가
   - 댓글이 자식 댓글(1-depth 대댓글)을 포함할 수 있도록 구조 확장

2. `getRootComments(Long communityId)` 메서드 구현
   - 루트 댓글(부모 댓글) 목록을 조회하고, 각 댓글에 해당하는 대댓글 리스트를 포함

3. `getReplies(Long parentId)` 메서드 구현
   - 특정 댓글 ID에 대한 대댓글만 단독으로 조회할 수 있도록 기능 분리

4. 내부 유틸 메서드 `toDtoWithReplies` 추가
   - 루트 댓글을 DTO로 변환하면서 자식 댓글을 포함하는 처리 담당

---

### ✅ 기대 효과
- 프론트엔드에서 댓글을 트리 구조로 쉽게 렌더링할 수 있도록 백엔드 구조 개선
- 대댓글 목록을 단독으로 요청하거나, 댓글과 함께 바로 내려받는 구조 모두 지원



closes #66

