### PR TITLE
Spring Security 설정 통합 및 커뮤니티 댓글 작성자ID 및 본인 여부 확인 필드 추가

### DIFF
--- a/src/main/java/com/project/Journey/community/comment/controller/CommunityCommentController.java
+++ b/src/main/java/com/project/Journey/community/comment/controller/CommunityCommentController.java
@@ -6,6 +6,7 @@ import com.project.Journey.community.comment.dto.CommunityCommentRequest;
 import com.project.Journey.community.comment.dto.CommunityCommentResponseDTO;
 import com.project.Journey.community.comment.entity.CommunityComment;
 import com.project.Journey.community.comment.service.CommunityCommentService;
+import com.project.Journey.login.auth.CustomUserDetails;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -16,6 +17,8 @@ import lombok.RequiredArgsConstructor;
 import lombok.Setter;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.AuthenticatedPrincipal;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -52,10 +55,13 @@ public class CommunityCommentController {
     })
     @GetMapping("/{communityId}/comments")
     public ResponseEntity<List<CommunityCommentResponseDTO>> getComments(
-            @PathVariable Long communityId) {
-
-        return ResponseEntity.ok(commentService.getRootComments(communityId));
+            @PathVariable Long communityId,
+            @AuthenticationPrincipal CustomUserDetails principal /* ← 현재 로그인 사용자  */
+    ) {
+        Long currentId = principal != null ? principal.getMember().getId() : null;
+        return ResponseEntity.ok(commentService.getRootComments(communityId, currentId));
     }
+
 
     @Getter @Setter
     static class UpdateRequest {

--- a/src/main/java/com/project/Journey/community/comment/dto/CommunityCommentResponseDTO.java
+++ b/src/main/java/com/project/Journey/community/comment/dto/CommunityCommentResponseDTO.java
@@ -17,13 +17,15 @@ public class CommunityCommentResponseDTO {
 
     private Long commentId;
     private Long communityId;
+    private Long writerId;     // 댓글 작성자 ID
+    private boolean isMine;
+
     private Long memberId;
     private String displayName;
     private String profileImage;
     private String content;
     private Long parentCommentId;
-    private int replyCount;
-    private int depth;
+    private int  replyCount;
     private boolean isActive;
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss", timezone = "Asia/Seoul")
     private LocalDateTime createdAt;
@@ -41,7 +43,6 @@ public class CommunityCommentResponseDTO {
                 .parentCommentId(
                         c.getParentComment() != null ? c.getParentComment().getCommentId() : null)
                 .replyCount(c.getReplyCount())
-                .depth(c.getParentComment() != null ? 1 : 0)
                 .isActive(c.isActive())
                 .createdAt(c.getCreatedAt())
                 .updatedAt(c.getUpdatedAt())
@@ -51,18 +52,19 @@ public class CommunityCommentResponseDTO {
     @Builder.Default
     private List<CommunityCommentResponseDTO> replies = List.of();
 
-    public static CommunityCommentResponseDTO of(CommunityComment c,
+    public static CommunityCommentResponseDTO of(CommunityComment c, boolean isMine,
                                                  List<CommunityCommentResponseDTO> replies) {
 
         return CommunityCommentResponseDTO.builder()
                 .commentId(c.getCommentId())
                 .communityId(c.getCommunity().getCommunityPostId())
                 .memberId(c.getMember().getId())
+                .writerId(c.getMember().getId())
+                .isMine(isMine)
                 .displayName(c.getMember().getDisplayName())
                 .profileImage(c.getMember().getProfileImage())
                 .content(c.getContent())
                 .parentCommentId(c.getParentComment() != null ? c.getParentComment().getCommentId() : null)
-                .depth(c.getParentComment() != null ? 1 : 0)
                 .isActive(c.isActive())
                 .createdAt(c.getCreatedAt())
                 .updatedAt(c.getUpdatedAt())
@@ -70,8 +72,8 @@ public class CommunityCommentResponseDTO {
                 .build();
     }
 
-    public static CommunityCommentResponseDTO of(CommunityComment c) {
-        return of(c, List.of());
+    public static CommunityCommentResponseDTO of(CommunityComment c, boolean isMine) {
+        return of(c, isMine, List.of());
     }
 
     public static CommunityCommentResponseDTO withReplies(CommunityComment root,
@@ -84,5 +86,7 @@ public class CommunityCommentResponseDTO {
     public static List<CommunityCommentResponseDTO> listOf(List<CommunityComment> list) {
         return list.stream().map(CommunityCommentResponseDTO::from).collect(Collectors.toList());
     }
+
+
 }
 

--- a/src/main/java/com/project/Journey/community/comment/service/CommunityCommentService.java
+++ b/src/main/java/com/project/Journey/community/comment/service/CommunityCommentService.java
@@ -53,32 +53,35 @@ public class CommunityCommentService {
     }
 
     @Transactional(readOnly = true)
-    public List<CommunityCommentResponseDTO> getRootComments(Long communityId) {
+    public List<CommunityCommentResponseDTO> getRootComments(Long communityId, Long currentMemberId) {
 
         Community community = communityRepo.findById(communityId)
                 .orElseThrow(() -> new IllegalArgumentException("커뮤니티 글이 없습니다"));
 
-        List<CommunityComment> roots =
-                commentRepo.findByCommunityAndParentCommentIsNullAndIsActiveTrueOrderByCreatedAtAsc(community);
-
-        return roots.stream()
-                .map(this::toDtoWithReplies)
+        return commentRepo
+                .findByCommunityAndParentCommentIsNullAndIsActiveTrueOrderByCreatedAtAsc(community)
+                .stream()
+                .map(c -> toDtoWithReplies(c, currentMemberId))
                 .toList();
     }
 
-    private CommunityCommentResponseDTO toDtoWithReplies(CommunityComment root) {
+    private CommunityCommentResponseDTO toDtoWithReplies(CommunityComment root, Long currentMemberId) {
 
-        List<CommunityCommentResponseDTO> children = commentRepo
+        boolean rootMine = root.getMember().getId().equals(currentMemberId);
+
+        List<CommunityCommentResponseDTO> childDtos = commentRepo
                 .findByParentCommentAndIsActiveTrueOrderByCreatedAtAsc(root)
                 .stream()
-                .map(CommunityCommentResponseDTO::of)
+                .map(child -> CommunityCommentResponseDTO.of(child,
+                        child.getMember().getId().equals(currentMemberId)))
                 .toList();
 
-        return CommunityCommentResponseDTO.of(root, children);
+        return CommunityCommentResponseDTO.of(root, rootMine, childDtos);
     }
 
+
     @Transactional(readOnly = true)
-    public List<CommunityCommentResponseDTO> getReplies(Long parentId) {
+    public List<CommunityCommentResponseDTO> getReplies(Long parentId, Long currentMemberId) {
 
         CommunityComment parent = commentRepo.findById(parentId)
                 .orElseThrow(() -> new IllegalArgumentException("댓글이 없습니다"));
@@ -86,7 +89,8 @@ public class CommunityCommentService {
         return commentRepo
                 .findByParentCommentAndIsActiveTrueOrderByCreatedAtAsc(parent)
                 .stream()
-                .map(CommunityCommentResponseDTO::of)
+                .map(child -> CommunityCommentResponseDTO.of(child,
+                        child.getMember().getId().equals(currentMemberId)))
                 .toList();
     }
 

--- a/src/main/java/com/project/Journey/login/auth/SecurityConfig.java
+++ b/src/main/java/com/project/Journey/login/auth/SecurityConfig.java
@@ -3,7 +3,6 @@ package com.project.Journey.login.auth;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.core.annotation.Order;
 import org.springframework.http.HttpMethod;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.Customizer;
@@ -11,7 +10,6 @@ import org.springframework.security.config.annotation.authentication.builders.Au
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
-import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.web.cors.CorsConfiguration;
@@ -21,21 +19,19 @@ import java.util.List;
 
 @Configuration
 @RequiredArgsConstructor
-@Order(2)
 @EnableWebSecurity
 public class SecurityConfig {
 
     private final CustomUserDetailsService userDetailsService;
 
-    // === 화이트리스트 경로 (예시) ===
+    // 화이트리스트 추후 수정예정
     private static final String[] WHITELIST = {
+            "/api/**",
             "/",
             "/api/oauth2/**",
             "/login",
-            "/loginHome",
-            "/signUp",
+            "/api/members/signup",
             "/renew",
-            "/loginSuccess",
             "/login/oauth2/code/**",
             "/oauth2/signUp",
             "/error",
@@ -54,96 +50,70 @@ public class SecurityConfig {
             "/api/**",
             "/WebSocketTest.html",
             "/ws/**",
+            "/topic/**",
             "/swagger-ui",
             "/api/auth/sign-up",
             "/api/oauth2/sign-up",
             "/oauth2/**"
     };
 
-    /**
-     * 비밀번호 암호화를 위한 Bean
-     */
     @Bean
     public BCryptPasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();
     }
 
-    /**
-     * AuthenticationManager Bean 등록
-     * DaoAuthenticationProvider를 자동으로 구성하여
-     * UserDetailsService + PasswordEncoder를 사용
-     */
     @Bean
-    public AuthenticationManager authenticationManager(HttpSecurity http) throws Exception {
-        // 예전처럼 .and()를 쓰지 않고 빌더 객체를 직접 받아 build() 합니다
-        AuthenticationManagerBuilder builder = http.getSharedObject(AuthenticationManagerBuilder.class);
-        builder
+    public AuthenticationManager authenticationManager(HttpSecurity http,
+                                                       BCryptPasswordEncoder encoder) throws Exception {
+        AuthenticationManagerBuilder authBuilder =
+                http.getSharedObject(AuthenticationManagerBuilder.class);
+
+        authBuilder
                 .userDetailsService(userDetailsService)
-                .passwordEncoder(passwordEncoder());
-        return builder.build();
+                .passwordEncoder(encoder);
+
+        return authBuilder.build();
     }
 
-    /**
-     * 메인 Security FilterChain 설정
-     */
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
-        // -- (A) CORS 설정
-        http.cors(cors -> cors.configurationSource(corsConfigurationSource()));
+        http
+                .cors(cors -> cors.configurationSource(corsConfigurationSource()))
+                .csrf(csrf -> csrf
+                        .ignoringRequestMatchers("/ws/**", "/topic/**", "/app/**", "/api/**"))
+                .sessionManagement(session -> session
+                        .sessionCreationPolicy(SessionCreationPolicy.IF_REQUIRED))
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
+                        .requestMatchers(WHITELIST).permitAll()
+                        .anyRequest().authenticated())
+                .formLogin(form -> form.disable())
+//                .oauth2Login(Customizer.withDefaults())
+                .httpBasic(httpBasic -> httpBasic.disable())
+                .logout(logout -> logout
+                        .logoutUrl("/logout")
+                        .invalidateHttpSession(true)
+                        .deleteCookies("JSESSIONID"));
 
-        // -- (B) CSRF 설정
-        // REST API 로만 사용 시 대체로 disable
-        // 만약 폼 전송(CSRF 토큰)이 필요하다면 enable
-        http.csrf(csrf -> csrf.disable());
-
-        // -- (C) 세션 정책
-        // 기본적으로 로그인 시 세션을 생성( IF_REQUIRED )
-        http.sessionManagement(session -> session
-                        .sessionCreationPolicy(SessionCreationPolicy.IF_REQUIRED)
-                // 필요 시 세션고정공격 방지, 만료처리, 등등
-        );
-
-        // -- (D) URL 보안
-        http.authorizeHttpRequests(auth -> auth
-                .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()  // 🔥 이 줄 추가!
-                .requestMatchers(WHITELIST).permitAll()
-                .anyRequest().authenticated()
-        );
-
-        // -- (E) formLogin, httpBasic 비활성(REST 방식을 가정)
-        http.formLogin(form -> form.disable());
-        http.httpBasic(basic -> basic.disable());
-
-        // -- (F) 로그아웃
-        http.logout(logout -> logout
-                .logoutUrl("/logout")
-                .invalidateHttpSession(true)
-                .deleteCookies("JSESSIONID")
-        );
-
-        // 최종 빌드
         return http.build();
     }
 
     @Bean
     public UrlBasedCorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration config = new CorsConfiguration();
-
         config.setAllowedOriginPatterns(List.of(
                 "http://localhost:5173",
+                "http://localhost:8080",
                 "https://dxkiwmo9p9ise.cloudfront.net",
                 "https://journeysite.site"
         ));
 
         config.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS"));
-
         config.setAllowedHeaders(List.of("*"));
-        config.setAllowCredentials(true); // 세션 쿠키 전송 허용
-        config.setMaxAge(3600L);         // Pre-flight 캐싱 시간(초)
+        config.setAllowCredentials(true);
+        config.setMaxAge(3600L);
 
-        // CORS 매핑
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
-        // 모든 경로에 대해 위 설정 적용
         source.registerCorsConfiguration("/**", config);
         return source;
     }

--- a/src/main/java/com/project/Journey/notification/config/WebSocketSecurityConfig.java
+++ b/src/main/java/com/project/Journey/notification/config/WebSocketSecurityConfig.java
@@ -1,30 +1,30 @@
-package com.project.Journey.notification.config;
-
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
-import org.springframework.core.annotation.Order;
-import org.springframework.security.config.annotation.web.WebSecurityConfigurer;
-import org.springframework.security.config.annotation.web.builders.HttpSecurity;
-import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
-import org.springframework.security.web.SecurityFilterChain;
-
-@Configuration
-@Order(1)
-public class WebSocketSecurityConfig {
-
-    @Bean
-    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
-        http
-                // 이 체인에서는 "/ws/**" 등 특정 경로만 보안 필터가 동작
-                .securityMatcher("/ws/**", "/topic/**", "/app/**", "/api/notification/**", "/WebSocketTest.html")
-
-                // CSRF 비활성화 (WebSocket 요청은 CSRF 보호가 필요 없음)
-                .csrf(csrf -> csrf.disable())
-                // 요청에 대한 권한 설정
-                .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/ws/**","/topic/**", "/app/**","/WebSocketTest.html","/api/notification/**").permitAll() // WebSocket 엔드포인트는 인증 없이 접근 허용
-                        .anyRequest().authenticated()        // 그 외 요청은 인증 필요
-                );
-        return http.build();
-    }
-}
+//package com.project.Journey.notification.config;
+//
+//import org.springframework.context.annotation.Bean;
+//import org.springframework.context.annotation.Configuration;
+//import org.springframework.core.annotation.Order;
+//import org.springframework.security.config.annotation.web.WebSecurityConfigurer;
+//import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+//import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+//import org.springframework.security.web.SecurityFilterChain;
+//
+//@Configuration
+//@Order(1)
+//public class WebSocketSecurityConfig {
+//
+//    @Bean
+//    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+//        http
+//                // 이 체인에서는 "/ws/**" 등 특정 경로만 보안 필터가 동작
+//                .securityMatcher("/ws/**", "/topic/**", "/app/**", "/api/notification/**", "/WebSocketTest.html")
+//
+//                // CSRF 비활성화 (WebSocket 요청은 CSRF 보호가 필요 없음)
+//                .csrf(csrf -> csrf.disable())
+//                // 요청에 대한 권한 설정
+//                .authorizeHttpRequests(auth -> auth
+//                        .requestMatchers("/ws/**","/topic/**", "/app/**","/WebSocketTest.html","/api/notification/**").permitAll() // WebSocket 엔드포인트는 인증 없이 접근 허용
+//                        .anyRequest().authenticated()        // 그 외 요청은 인증 필요
+//                );
+//        return http.build();
+//    }
+//}


### PR DESCRIPTION
## 📌 개요
기존에 분리되어 있던 `SecurityConfig`(일반 API용)와 `WebSocketSecurityConfig`를 하나의 필터 체인으로 통합하였습니다. 또한 OAuth2 로그인 시 발생하던 `ClientRegistrationRepository` 관련 에러를 해결하기 위해 설정을 보완하였습니다.

 또한, 지난번에 진행했던 커뮤니티 게시글 작성자 Id 및 본인 여부 확인 필드를 추가하여, 프론트에서 댓글 수정 및 삭제 권한 구현에 어려움이 없도록 기능을 추가했습니다.

---

## 🔧 주요 변경 사항

1. Spring Security

- `SecurityConfig`에서 WebSocket 경로(`/ws/**`, `/topic/**`, `/app/**`, `/WebSocketTest.html`)에 대한 CSRF 예외 및 접근 허용 처리 통합
- CORS 설정 유지 (`localhost`, CloudFront, journey 도메인 허용)
- `ClientRegistrationRepository` 관련 기동 에러 해결을 위한 설정 보완
- 중복된 `SecurityFilterChain` 클래스(WebSocketSecurityConfig) 제거
- 불필요한 whitelist 제거 및 정리

2. 커뮤니티 댓글 조회 및 응답에 작성자 ID 및 본인 여부 필드 추가
- writerId 필드 추가 (게시글 작성자 ID 전달)
- isMine 필드 추가 (현재 로그인 사용자가 작성자인지 여부)

closes #73
closes #74