### PR TITLE
[Fix] id 기준으로 팔로우(팔로잉) 메서드 수정(#50)

### DIFF
--- a/src/main/java/com/project/Journey/login/follow/controller/FollowController.java
+++ b/src/main/java/com/project/Journey/login/follow/controller/FollowController.java
@@ -2,7 +2,7 @@ package com.project.Journey.login.follow.controller;
 
 import com.project.Journey.login.follow.dto.FollowRequestDTO;
 import com.project.Journey.login.follow.dto.FollowResponseDTO;
-import com.project.Journey.login.follow.service.FollwService;
+import com.project.Journey.login.follow.service.FollowService;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -24,30 +24,30 @@ import java.util.List;
 @RequiredArgsConstructor
 public class FollowController {
 
-    private final FollwService follwService;
+    private final FollowService followService;
 
     //팔로우
-    //http://localhost:8080/api/follow?myLoginId=user1
+    //http://localhost:8080/api/follow?myMemberId=1
     @Operation(
         summary = "팔로우 요청",
         description = """
             로그인한 사용자가 다른 사용자를 팔로우합니다.
             
-            POST http://localhost:8080/api/follow?myLoginId=user1
+            POST http://localhost:8080/api/follow?myMemberId=1
                         
             request :\s
             {
-              "targetLoginId": "user2"
+              "targetMemberId": 2
             }
             
-            -> user1이 user2를 팔로우 함
+            -> memberId가 1인 사용자가 memberId가 2인 사용자를 팔로우 함
             
             """,
         parameters = {
-            @Parameter(name = "myLoginId", description = "팔로우를 요청하는 자신의 로그인 ID", required = true, in = ParameterIn.QUERY)
+            @Parameter(name = "myMemberId", description = "팔로우를 요청하는 자신의 memberID", required = true, in = ParameterIn.QUERY)
         },
         requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(
-            description = "팔로우 대상 ID",
+            description = "팔로우 대상 memberId",
             required = true,
             content = @Content(schema = @Schema(implementation = FollowRequestDTO.class))
         ),
@@ -58,26 +58,26 @@ public class FollowController {
         }
     )
     @PostMapping("/api/follow")
-    public ResponseEntity<Void> follow(@RequestParam String myLoginId,  @RequestBody FollowRequestDTO request){
-        follwService.follow(myLoginId, request.getTargetLoginId());
+    public ResponseEntity<Void> follow(@RequestParam Long myMemberId,  @RequestBody FollowRequestDTO request){
+        followService.follow(myMemberId, request.getTargetMemberId());
         return ResponseEntity.ok().build();
     }
 
     //언팔로우
-    //http://localhost:8080/api/unfollow?myLoginId=user3&targetId=user1
+    //http://localhost:8080/api/unfollow?myMemberId=1&targetMemberId=2
     @Operation(
         summary = "언팔로우 요청",
         description = """
             로그인한 사용자가 다른 사용자를 언팔로우합니다.
             
-            DELETE http://localhost:8080/api/unfollow?myLoginId=user3&targetId=user1
+            DELETE http://localhost:8080/api/unfollow?myMemberId=1&targetMemberId=2
                         
-            -> user3가 user1을 언팔로우
+            -> memberId가 1인 사용자가 memberId가 2인 사용자를 언팔로우
             
             """,
         parameters = {
-            @Parameter(name = "myLoginId", description = "언팔로우를 요청하는 자신의 로그인 ID", required = true, in = ParameterIn.QUERY),
-            @Parameter(name = "targetId", description = "언팔로우 대상 로그인 ID", required = true, in = ParameterIn.QUERY)
+            @Parameter(name = "myMemberId", description = "언팔로우를 요청하는 자신의 memberId", required = true, in = ParameterIn.QUERY),
+            @Parameter(name = "targetMemberId", description = "언팔로우 대상 memberId", required = true, in = ParameterIn.QUERY)
         },
         responses = {
             @ApiResponse(responseCode = "200", description = "언팔로우 성공"),
@@ -86,27 +86,27 @@ public class FollowController {
         }
     )
     @DeleteMapping("/api/unfollow")
-    public ResponseEntity<Void> unfollow(@RequestParam String myLoginId, @RequestParam String targetId) {
-        follwService.unfollow(myLoginId, targetId);
+    public ResponseEntity<Void> unfollow(@RequestParam Long myMemberId, @RequestParam Long targetMemberId) {
+        followService.unfollow(myMemberId, targetMemberId);
         return ResponseEntity.ok().build();
     }
 
 
 
     //팔로잉한 사람들 리스트 가져오기
-    //http://localhost:8080/api/follow/following?memberLoginId=user1
+    //http://localhost:8080/api/follow/following?memberId=1
     @Operation(
         summary = "팔로잉 목록 조회",
         description = """
             특정 사용자가 팔로잉 중인 사용자 목록을 반환합니다.
             
-            GET http://localhost:8080/api/follow/following?memberLoginId=user1
+            GET http://localhost:8080/api/follow/following?memberId=1
                         
-            -> user1이 팔로잉한 사람들 리스트 가져옵니다
+            -> memberId가 1인 사용자가 팔로잉한 사람들 리스트 가져옵니다
             response 예시
             [
                 {
-                    "memberId": 1,
+                    "memberId": 2,
                     "username": "미국여행자",
                     "profileImageUrl": null
                 },
@@ -121,7 +121,7 @@ public class FollowController {
             
             """,
         parameters = {
-            @Parameter(name = "memberLoginId", description = "조회할 사용자의 로그인 ID", required = true, in = ParameterIn.QUERY)
+            @Parameter(name = "memberId", description = "조회할 사용자의 memberId", required = true, in = ParameterIn.QUERY)
         },
         responses = {
             @ApiResponse(responseCode = "200", description = "조회 성공",
@@ -131,8 +131,8 @@ public class FollowController {
         }
     )
     @GetMapping("/api/follow/following")
-    public List<FollowResponseDTO> getFollowing(@RequestParam String memberLoginId){
-        return follwService.getFollowingList(memberLoginId);
+    public List<FollowResponseDTO> getFollowing(@RequestParam Long memberId){
+        return followService.getFollowingList(memberId);
     }
 
     //팔로우한 사람들 리스트 가져오기
@@ -141,9 +141,9 @@ public class FollowController {
         description = """
             특정 사용자를 팔로우 중인 사용자 목록을 반환합니다.
             
-            GET http://localhost:8080/api/follow/followers?memberLoginId=user1
+            GET http://localhost:8080/api/follow/followers?memberId=1
                         
-            -> user1을 팔로우한 사람들 리스트 가져옵니다
+            -> memberId가 1인 사용자를 팔로우한 사람들 리스트 가져옵니다
             response 예시
             [
                 {
@@ -160,7 +160,7 @@ public class FollowController {
             
             """,
         parameters = {
-            @Parameter(name = "memberLoginId", description = "조회할 사용자의 로그인 ID", required = true, in = ParameterIn.QUERY)
+            @Parameter(name = "memberId", description = "조회할 사용자의 memberId", required = true, in = ParameterIn.QUERY)
         },
         responses = {
             @ApiResponse(responseCode = "200", description = "조회 성공",
@@ -170,7 +170,7 @@ public class FollowController {
         }
     )
     @GetMapping("/api/follow/followers")
-    public List<FollowResponseDTO> getFollowers(@RequestParam String memberLoginId){
-        return follwService.getFollowerList(memberLoginId);
+    public List<FollowResponseDTO> getFollowers(@RequestParam Long memberId){
+        return followService.getFollowerList(memberId);
     }
 }

--- a/src/main/java/com/project/Journey/login/follow/dto/FollowRequestDTO.java
+++ b/src/main/java/com/project/Journey/login/follow/dto/FollowRequestDTO.java
@@ -8,8 +8,6 @@ import lombok.Setter;
 @Setter
 public class FollowRequestDTO {
 
-    @Schema(description = "팔로우할 대상 로그인 ID", example = "user2", required = true)
-    private String targetLoginId; //팔로우할 대상 사용자의 로그인 아이디
-
-    //private Long targetId; // 팔로우할 대상 사용자 ID
+    @Schema(description = "팔로우할 대상 memberId", example = "2", required = true)
+    private Long targetMemberId; //팔로우할 대상 사용자의 memberId
 }

--- a/src/main/java/com/project/Journey/login/follow/service/FollowService.java
+++ b/src/main/java/com/project/Journey/login/follow/service/FollowService.java
@@ -15,19 +15,19 @@ import java.util.NoSuchElementException;
 
 @Service
 @RequiredArgsConstructor
-public class FollwService {
+public class FollowService {
 
     private final FollowRepository followRepository;
     private final MemberRepository memberRepository;
 
     //팔로우
-    public void follow(String myLoginId, String targetLoginId){
-        Member me = memberRepository.findByLoginId(myLoginId).orElseThrow(() -> new EntityNotFoundException("내 계정이 존재하지 않습니다: " + myLoginId));
+    public void follow(Long myMemberId, Long targetMemberId){
+        Member me = memberRepository.findById(myMemberId).orElseThrow(() -> new EntityNotFoundException("내 계정이 존재하지 않습니다: " + myMemberId));
 
-        Member target = memberRepository.findByLoginId(targetLoginId).orElseThrow(() -> new EntityNotFoundException("팔로우 대상 계정이 존재하지 않습니다: " + targetLoginId));
+        Member target = memberRepository.findById(targetMemberId).orElseThrow(() -> new EntityNotFoundException("팔로우 대상 계정이 존재하지 않습니다: " + targetMemberId));
 
         if(followRepository.existsByFollowerAndFollowing(me, target)){
-            throw new IllegalStateException(me+"는 이미"+target+"을 팔로우하고 있습니다.");
+            throw new IllegalStateException("memberId가 "+myMemberId+"인 사용자는 이미 memberId가 "+targetMemberId+"인 사용자를 팔로우하고 있습니다.");
         }
 
         Follow follow = new Follow();
@@ -38,11 +38,11 @@ public class FollwService {
     }
 
     //언팔로우
-    public void unfollow(String myLoginId, String targetLoginId){
-        Member me = memberRepository.findByLoginId(myLoginId).orElseThrow(() -> new EntityNotFoundException("내 계정이 존재하지 않습니다: " + myLoginId));
+    public void unfollow(Long myMemberId, Long targetMemberId){
+        Member me = memberRepository.findById(myMemberId).orElseThrow(() -> new EntityNotFoundException("내 계정이 존재하지 않습니다: " + myMemberId));
 
-        Member target = memberRepository.findByLoginId(targetLoginId)
-                .orElseThrow(() -> new EntityNotFoundException("언팔로우 대상 계정이 존재하지 않습니다: " + targetLoginId));
+        Member target = memberRepository.findById(targetMemberId)
+                .orElseThrow(() -> new EntityNotFoundException("언팔로우 대상 계정이 존재하지 않습니다: " + targetMemberId));
 
         Follow follow = followRepository.findByFollowerAndFollowing(me, target)
                 .orElseThrow(()-> new IllegalStateException("팔로우 관계가 존재하지 않습니다."));
@@ -51,8 +51,8 @@ public class FollwService {
     }
 
     //팔로잉 리스트 가져오기
-    public List<FollowResponseDTO> getFollowingList(String LoginId){
-        Member member = memberRepository.findByLoginId(LoginId).orElseThrow(() -> new EntityNotFoundException(LoginId+"의 계정이 존재하지 않습니다."));
+    public List<FollowResponseDTO> getFollowingList(Long memberId){
+        Member member = memberRepository.findById(memberId).orElseThrow(() -> new EntityNotFoundException("memberId가 "+memberId+"인 사용자가 존재하지 않습니다."));
 
         List<Follow> follows = followRepository.findByFollower(member);
         List<FollowResponseDTO> result = new ArrayList<>();
@@ -67,8 +67,8 @@ public class FollwService {
     }
 
     //팔로워 리스트 가져오기
-    public List<FollowResponseDTO> getFollowerList(String LoginId){
-        Member member = memberRepository.findByLoginId(LoginId).orElseThrow(() -> new EntityNotFoundException(LoginId+"의 계정이 존재하지 않습니다."));
+    public List<FollowResponseDTO> getFollowerList(Long memberId){
+        Member member = memberRepository.findById(memberId).orElseThrow(() -> new EntityNotFoundException("memberId가 "+memberId+"인 사용자가 존재하지 않습니다."));
         List<Follow> follows = followRepository.findByFollowing(member);
 
         List<FollowResponseDTO> result = new ArrayList<>();


### PR DESCRIPTION
## 작업내용
### 🔧 팔로우(팔로잉) 메서드 수정 이슈 (#50) 작업
✅FollwService -> FollowService로 **클래스 Rename**
기존의 오타난 Follw 부분을 Follow로 알맞게 클래스명을 수정해주었습니다

✅ **loginId -> memberId로** CRUD API 쿼리 파라미터 **리펙토링**
기존의 메서드들의 매개변수는 loginId로 만들었었는데, 유저가 loginId값이 변경될 수 있으므로
PK인 memberId로 CRUD를 수정했습니다.