### PR TITLE
fix: 커뮤니티 게시글 목록에서 댓글 수가 항상 0으로 표시되는 문제 해결

### DIFF
--- a/src/main/java/com/project/Journey/community/dto/CommunityPageResponseDTO.java
+++ b/src/main/java/com/project/Journey/community/dto/CommunityPageResponseDTO.java
@@ -26,8 +26,12 @@ public class CommunityPageResponseDTO {
                 .communityPostId(community.getCommunityPostId())
                 .title(community.getTitle())
                 .nickname(community.getMember().getNickname())
-                .commentCount(community.getComment_count())
                 .createdAt(community.getCreatedAt())
+                .commentCount(
+                        community.getComments() != null
+                                ? (int) community.getComments().stream().filter(c -> c.getParentComment() == null).count()
+                                : 0
+                ) // 대댓글 제외하고 루트 댓글만 카운트할 수도 있음
                 .build();
     }
 }

--- a/src/main/java/com/project/Journey/community/entity/Community.java
+++ b/src/main/java/com/project/Journey/community/entity/Community.java
@@ -1,5 +1,6 @@
 package com.project.Journey.community.entity;
 
+import com.project.Journey.community.comment.entity.CommunityComment;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -27,6 +28,8 @@ public class Community {
     @JoinColumn(name = "member_id", nullable = false)
     private Member member;
 
+    @OneToMany(mappedBy = "community", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<CommunityComment> comments = new ArrayList<>();
 
     //커뮤니티 국가
     @Column(name = "country", nullable = false)


### PR DESCRIPTION
## 변경 내용
- Community 엔티티에 댓글 리스트(comments) 연결 (@OneToMany)
- CommunityPageResponseDTO.fromEntity()에서 댓글 수를 동적으로 계산하도록 수정

## 원인
- 기존 comment_count 필드는 DB에 저장된 정적 값으로, 댓글 추가/삭제 시 갱신되지 않아 항상 0으로 표시됨

## 해결
- fromEntity() 내부에서 community.getComments().size()를 통해 실시간 댓글 수 계산