### PR TITLE
[Fix] 게시글 검색 조건 중 nickname 필드 조인 방식 수정

### DIFF
--- a/src/main/java/com/project/Journey/companion/paging/PostSpecification.java
+++ b/src/main/java/com/project/Journey/companion/paging/PostSpecification.java
@@ -2,6 +2,8 @@ package com.project.Journey.companion.paging;
 
 import com.project.Journey.companion.dto.PostSearchRequest;
 import com.project.Journey.companion.entity.Post;
+import jakarta.persistence.criteria.Join;
+import jakarta.persistence.criteria.JoinType;
 import jakarta.persistence.criteria.Predicate;
 import org.springframework.data.jpa.domain.Specification;
 
@@ -19,7 +21,8 @@ public class PostSpecification {
             }
 
             if (request.getNickname() != null && !request.getNickname().isEmpty()) {
-                predicates.add(builder.equal(root.get("user_id"), request.getNickname()));
+                Join<Object, Object> memberJoin = root.join("member", JoinType.INNER);
+                predicates.add(builder.like(memberJoin.get("nickname"), "%" + request.getNickname() + "%"));
             }
 
             if (request.getCountry() != null && !request.getCountry().isEmpty()) {


### PR DESCRIPTION
- user_id로 되어 있는 부분 nickname으로 변경

## 📄 PR 설명
게시글 검색 시 nickname 조건으로 필터링할 경우 발생하던 500 오류를 해결했습니다.
기존 user_id 필드를 직접 접근하려던 방식에서, member 객체 조인을 통해 nickname 필드를 조회하도록 변경했습니다.

관련이슈
closes #88