### PR TITLE
feat: Country 목록 반환 API 개발

### DIFF
--- a/src/main/java/com/project/Journey/common/country/controller/CountryController.java
+++ b/src/main/java/com/project/Journey/common/country/controller/CountryController.java
@@ -1,0 +1,31 @@
+package com.project.Journey.common.country.controller;
+
+import com.project.Journey.common.country.service.CountryService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@Tag(name = "공통", description = "국가명 상수 API")
+@RestController
+@RequestMapping("/api/common/countries")
+@RequiredArgsConstructor
+public class CountryController {
+
+    private final CountryService countryService;
+
+    @Operation(
+            summary = "국가 이름 목록(한글로 7개)",
+            description = """
+                    프론트에서 사용되는 고정 7개 한글 국가명을 배열로 반환
+                    """
+    )
+    @GetMapping("/countries")
+    public List<String> listCountries() {
+        return countryService.getCountryNames();   // 200 OK
+    }
+}

--- a/src/main/java/com/project/Journey/common/country/service/CountryService.java
+++ b/src/main/java/com/project/Journey/common/country/service/CountryService.java
@@ -1,0 +1,20 @@
+package com.project.Journey.common.country.service;
+
+import lombok.Getter;
+import org.springframework.stereotype.Service;
+import java.util.List;
+
+@Service
+public class CountryService {
+
+    @Getter
+    private final List<String> countryNames = List.of(
+            "국내",
+            "일본",
+            "미국",
+            "프랑스",
+            "독일",
+            "중국",
+            "베트남"
+    );
+}


### PR DESCRIPTION
## 개발 내용
- 프런트에서 회원가입‧게시글 작성 등 “국가 선택” 드롭다운에 사용할 고정 국가 목록이 필요했습니다.
- 상수(enum + list) 방식으로 간단히 제공하며, /api/common/countries GET 한 번으로 모든 한글 국가명을 내려줍니다.

