### PR TITLE
fix: 삭제된 부모 댓글의 자식 댓글이 조회되지 않던 문제 수정

### DIFF
--- a/src/main/java/com/project/Journey/community/comment/dto/CommunityCommentResponseDTO.java
+++ b/src/main/java/com/project/Journey/community/comment/dto/CommunityCommentResponseDTO.java
@@ -63,7 +63,7 @@ public class CommunityCommentResponseDTO {
                 .isMine(isMine)
                 .displayName(c.getMember().getDisplayName())
                 .profileImage(c.getMember().getProfileImage())
-                .content(c.getContent())
+                .content(c.isActive() ? c.getContent() : "삭제된 댓글입니다.")
                 .parentCommentId(c.getParentComment() != null ? c.getParentComment().getCommentId() : null)
                 .isActive(c.isActive())
                 .createdAt(c.getCreatedAt())

--- a/src/main/java/com/project/Journey/community/comment/entity/CommunityComment.java
+++ b/src/main/java/com/project/Journey/community/comment/entity/CommunityComment.java
@@ -40,10 +40,6 @@ public class CommunityComment {
     @Column(nullable = false)
     private boolean isActive = true;
 
-    @OneToMany(mappedBy = "parentComment", cascade = CascadeType.ALL)
-    private List<CommunityComment> replies = new ArrayList<>();
-
-
     @Column(nullable = false)
     private int replyCount = 0;
 

--- a/src/main/java/com/project/Journey/community/comment/repository/CommunityCommentRepository.java
+++ b/src/main/java/com/project/Journey/community/comment/repository/CommunityCommentRepository.java
@@ -7,6 +7,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.List;
 
 public interface CommunityCommentRepository extends JpaRepository<CommunityComment, Long> {
-    List<CommunityComment> findByCommunityAndParentCommentIsNullAndIsActiveTrueOrderByCreatedAtAsc(Community community);
+    List<CommunityComment> findByCommunityAndParentCommentIsNullOrderByCreatedAtAsc(Community community);
     List<CommunityComment> findByParentCommentAndIsActiveTrueOrderByCreatedAtAsc(CommunityComment parent);
+    List<CommunityComment> findByParentComment_CommentIdAndIsActiveTrueOrderByCreatedAtAsc(Long parentId);
+
 }

--- a/src/main/java/com/project/Journey/community/comment/service/CommunityCommentService.java
+++ b/src/main/java/com/project/Journey/community/comment/service/CommunityCommentService.java
@@ -85,7 +85,7 @@ public class CommunityCommentService {
                 .orElseThrow(() -> new IllegalArgumentException("커뮤니티 글이 없습니다"));
 
         return commentRepo
-                .findByCommunityAndParentCommentIsNullAndIsActiveTrueOrderByCreatedAtAsc(community)
+                .findByCommunityAndParentCommentIsNullOrderByCreatedAtAsc(community)
                 .stream()
                 .map(c -> toDtoWithReplies(c, currentMemberId))
                 .toList();
@@ -113,7 +113,7 @@ public class CommunityCommentService {
                 .orElseThrow(() -> new IllegalArgumentException("댓글이 없습니다"));
 
         return commentRepo
-                .findByParentCommentAndIsActiveTrueOrderByCreatedAtAsc(parent)
+                .findByParentComment_CommentIdAndIsActiveTrueOrderByCreatedAtAsc(parentId)
                 .stream()
                 .map(child -> CommunityCommentResponseDTO.of(child,
                         child.getMember().getId().equals(currentMemberId)))


### PR DESCRIPTION
- Repository 쿼리에서 isActive 조건 제거 → 삭제된 부모 댓글도 포함되도록 수정
- Service/DTO 단에서 삭제 여부를 판단하여 '삭제된 댓글입니다'로 표시 예정
- 자식 댓글이 정상적으로 조회되어 UI에 노출됨