### PR TITLE
feat: 알림(Notification)에 postId 및 postType 처리 로직 적용 (#97)

### DIFF
--- a/src/main/java/com/project/Journey/community/comment/service/CommunityCommentService.java
+++ b/src/main/java/com/project/Journey/community/comment/service/CommunityCommentService.java
@@ -10,6 +10,7 @@ import com.project.Journey.community.repository.CommunityRepository;
 import com.project.Journey.login.member.domain.Member;
 import com.project.Journey.login.member.repository.MemberRepository;
 import com.project.Journey.notification.entity.NotificationType;
+import com.project.Journey.notification.entity.PostType;
 import com.project.Journey.notification.service.NotificationService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -59,7 +60,9 @@ public class CommunityCommentService {
                         member,
                         NotificationType.COMMENT,
                         member.getDisplayName() + "님 댓글을 남겼습니다.",
-                        "/community-board/" + community.getCountry() + "/" + community.getCommunityPostId()
+                        "/community-board/" + community.getCountry() + "/" + community.getCommunityPostId(),
+                        community.getCommunityPostId(),          // postId
+                        PostType.COMMUNITY                       // postType (enum)
                 );
             }
         } else {
@@ -70,7 +73,9 @@ public class CommunityCommentService {
                         member,
                         NotificationType.REPLY,
                         member.getDisplayName() + "님이 대댓글을 남겼습니다.",
-                        "/community-board/" + community.getCountry() + "/" + community.getCommunityPostId() + "?commentId=" + parent.getCommentId()
+                        "/community-board/" + community.getCountry() + "/" + community.getCommunityPostId() + "?commentId=" + parent.getCommentId(),
+                        community.getCommunityPostId(),
+                        PostType.COMMUNITY
                 );
             }
         }

--- a/src/main/java/com/project/Journey/companion/comment/service/CommentService.java
+++ b/src/main/java/com/project/Journey/companion/comment/service/CommentService.java
@@ -11,6 +11,7 @@ import com.project.Journey.companion.repository.PostRepository;
 import com.project.Journey.login.member.domain.Member;
 import com.project.Journey.login.member.repository.MemberRepository;
 import com.project.Journey.notification.entity.NotificationType;
+import com.project.Journey.notification.entity.PostType;
 import com.project.Journey.notification.service.NotificationService;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
@@ -61,7 +62,9 @@ public class CommentService {
                         member,
                         NotificationType.COMMENT,
                         member.getDisplayName() + "님이 댓글을 남겼습니다.",
-                        "/companion-board/" + post.getCountry() + "/" + post.getPostId()
+                        "/companion-board/" + post.getCountry() + "/" + post.getPostId(),
+                        post.getPostId(),                         // postId
+                        PostType.COMPANION                        // postType
                 );
             }
         } else {
@@ -72,7 +75,9 @@ public class CommentService {
                         member,
                         NotificationType.REPLY,
                         member.getDisplayName() + "님이 대댓글을 남겼습니다.",
-                        "/companion-board/" + post.getCountry() + "/" + post.getPostId() + "?commentId=" + parent.getCommentId()
+                        "/companion-board/" + post.getCountry() + "/" + post.getPostId() + "?commentId=" + parent.getCommentId(),
+                        post.getPostId(),
+                        PostType.COMPANION
                 );
             }
         }

--- a/src/main/java/com/project/Journey/notification/entity/Notification.java
+++ b/src/main/java/com/project/Journey/notification/entity/Notification.java
@@ -47,6 +47,13 @@ public class Notification {
     @Column(nullable = false)
     private boolean isDeleted = false;
 
+    @Column(nullable = false)
+    private Long postId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private PostType postType;
+
     public void delete() {
         this.isDeleted = true;
     }

--- a/src/main/java/com/project/Journey/notification/entity/PostType.java
+++ b/src/main/java/com/project/Journey/notification/entity/PostType.java
@@ -1,0 +1,6 @@
+package com.project.Journey.notification.entity;
+
+public enum PostType {
+    COMMUNITY,
+    COMPANION
+}

--- a/src/main/java/com/project/Journey/notification/service/NotificationService.java
+++ b/src/main/java/com/project/Journey/notification/service/NotificationService.java
@@ -4,6 +4,7 @@ import com.project.Journey.login.member.domain.Member;
 import com.project.Journey.notification.dto.NotificationDTO;
 import com.project.Journey.notification.entity.Notification;
 import com.project.Journey.notification.entity.NotificationType;
+import com.project.Journey.notification.entity.PostType;
 import com.project.Journey.notification.repository.NotificationRepository;
 
 import jakarta.persistence.EntityManager;
@@ -33,7 +34,9 @@ public class NotificationService {
                      @Nullable Member sender,
                      NotificationType type,
                      String message,
-                     String link) {
+                     String link,
+                     Long postId,
+                     PostType postType) {
         if (sender != null && sender.getId().equals(receiver.getId())) {
             return;
         }
@@ -44,6 +47,8 @@ public class NotificationService {
                 .type(type)
                 .message(message)
                 .link(link)
+                .postId(postId)
+                .postType(postType)
                 .build());
 
         simpMessagingTemplate.convertAndSend("/topic/users/" + receiver.getId() + "/notifications", NotificationDTO.from(saved));
@@ -86,6 +91,6 @@ public class NotificationService {
 
         NotificationType notificationType = NotificationType.valueOf(type.toUpperCase());
 
-        push(receiver, sender, notificationType, message, link);
+        push(receiver, sender, notificationType, message, link, 1L, PostType.COMMUNITY);
     }
 }


### PR DESCRIPTION
- Notification 엔티티에 postId, postType 필드 추가
- NotificationService.push() 시그니처 확장 (postId, postType 파라미터 추가)
- CommunityCommentService와 CompanionCommentService에서 알림 생성 시 게시글 ID 및 타입 전달
- PostType enum(COMMUNITY, COMPANION) 정의 및 사용