### PR TITLE
[Feat] 이미지 크기 제한 설정(5MB) 및 소셜로그인 이메일 중복 검사 기능 구현

### DIFF
--- a/src/main/java/com/project/Journey/awss3/S3Controller.java
+++ b/src/main/java/com/project/Journey/awss3/S3Controller.java
@@ -68,6 +68,10 @@ public class S3Controller {
             @RequestParam("file") MultipartFile file,
             @RequestParam("role") MemberRole role
     ) {
+        if (file.getSize() > 5 * 1024 * 1024) {
+            return ResponseEntity.badRequest().body("5MB 이하의 파일만 업로드할 수 있습니다.");
+        }
+
         String imageUrl = s3Service.uploadProfileImage(file, role);
         return ResponseEntity.ok(imageUrl);
     }
@@ -113,6 +117,10 @@ public class S3Controller {
     public ResponseEntity<String> uploadApplicationImage(
             @RequestParam("file") MultipartFile file
     ) {
+        if (file.getSize() > 5 * 1024 * 1024) {
+            return ResponseEntity.badRequest().body("5MB 이하의 파일만 업로드할 수 있습니다.");
+        }
+
         String imageUrl = s3Service.uploadApplicationImage(file);
         return ResponseEntity.ok(imageUrl);
     }

--- a/src/main/java/com/project/Journey/login/member/repository/MemberRepository.java
+++ b/src/main/java/com/project/Journey/login/member/repository/MemberRepository.java
@@ -18,4 +18,5 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findByLoginId(String loginId);
     Optional<Member> findByEmail(String email);
     Optional<Member> findBySocialTypeAndSocialId(SocialType socialType, String socialId);
+    List<Member> findAllBySocialTypeAndSocialId(SocialType socialType, String socialId);
 }

--- a/src/main/java/com/project/Journey/login/oauth2/service/OAuth2UserService.java
+++ b/src/main/java/com/project/Journey/login/oauth2/service/OAuth2UserService.java
@@ -19,6 +19,7 @@ import org.springframework.web.reactive.function.client.WebClient;
 import org.springframework.web.reactive.function.client.WebClientResponseException;
 
 import java.time.Duration;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -78,13 +79,28 @@ public class OAuth2UserService {
         String socialId = userInfo.getSocialId();
         String email = userInfo.getEmail();
 
-        Optional<Member> optional = memberRepository.findBySocialTypeAndSocialId(socialType, socialId);
+        Optional<Member> existingMember = memberRepository.findByEmail(email);
+        if (existingMember.isPresent()) {
+            Member existing = existingMember.get();
+            if (!existing.getSocialType().equals(socialType)) {
+                throw new IllegalArgumentException(
+                        "이미 다른 방식(" + (existing.getSocialType() != null ? existing.getSocialType() : "일반 가입") + ")으로 가입된 이메일입니다."
+                );
+            }
+        }
+
+        List<Member> members = memberRepository.findAllBySocialTypeAndSocialId(socialType, socialId);
+        if (members.size() > 1) {
+            throw new IllegalStateException("중복된 소셜 ID로 인해 로그인할 수 없습니다.");
+        }
+
+        Optional<Member> optional = members.stream().findFirst(); // 이미 조회했으므로 재조회 생략
 
         if (optional.isPresent()) {
             log.info("[OAuth2UserService] 기존 소셜회원: {}, {}", socialType, email);
             return optional.get();
         } else {
-            // 신규 가입
+            // 4. 신규 가입
             Member newMember = Member.builder()
                     .socialType(socialType)
                     .socialId(socialId)
@@ -96,6 +112,7 @@ public class OAuth2UserService {
             log.info("[OAuth2UserService] 새 소셜회원 가입: {}, {}", socialType, email);
             return newMember;
         }
+
     }
 
     private OAuth2UserInfo getKakaoUserInfo(String code) {

--- a/src/main/java/com/project/Journey/login/oauth2/userInfo/GoogleOAuth2UserInfo.java
+++ b/src/main/java/com/project/Journey/login/oauth2/userInfo/GoogleOAuth2UserInfo.java
@@ -16,4 +16,9 @@ public class GoogleOAuth2UserInfo extends OAuth2UserInfo {
     public String getEmail(){
         return String.valueOf(attributes.get("email"));
     }
+
+    @Override
+    public String getName() {
+        return String.valueOf(attributes.get("name"));
+    }
 }

--- a/src/main/java/com/project/Journey/login/oauth2/userInfo/KakaoOAuth2UserInfo.java
+++ b/src/main/java/com/project/Journey/login/oauth2/userInfo/KakaoOAuth2UserInfo.java
@@ -27,5 +27,10 @@ public class KakaoOAuth2UserInfo extends OAuth2UserInfo {
     public String getEmail() {
         return (String) account.get("email");   // null이면 그대로 null 반환
     }
+
+    @Override
+    public String getName() {
+        return (String) profile.get("nickname"); // nickname은 카카오 기본 제공 항목
+    }
 }
 

--- a/src/main/java/com/project/Journey/login/oauth2/userInfo/NaverOAuth2UserInfo.java
+++ b/src/main/java/com/project/Journey/login/oauth2/userInfo/NaverOAuth2UserInfo.java
@@ -20,4 +20,9 @@ public class NaverOAuth2UserInfo extends OAuth2UserInfo {
     public String getEmail() {
         return String.valueOf(responseMap.get("email"));
     }
+
+    @Override
+    public String getName() {
+        return String.valueOf(responseMap.get("name"));
+    }
 }

--- a/src/main/java/com/project/Journey/login/oauth2/userInfo/OAuth2UserInfo.java
+++ b/src/main/java/com/project/Journey/login/oauth2/userInfo/OAuth2UserInfo.java
@@ -13,4 +13,5 @@ public abstract class OAuth2UserInfo {
     // 소셜에서 제공받은 정보를 추출하기 위한 메서드
     public abstract String getSocialId();
     public abstract String getEmail();
+    public abstract String getName();
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -7,7 +7,6 @@ spring.jpa.hibernate.ddl-auto=update
 spring.jpa.show-sql=true
 spring.jpa.database-platform=org.hibernate.dialect.MySQLDialect
 
-
 # Redis
 spring.redis.host=127.0.0.1
 spring.redis.port=6379
@@ -48,3 +47,6 @@ aws.secret-key=${AWS_SECRET_KEY}
 
 # 전역시간 Asia/Seoul
 spring.jackson.time-zone=Asia/Seoul 
+
+spring.servlet.multipart.max-file-size=10MB
+spring.servlet.multipart.max-request-size=10MB


### PR DESCRIPTION
## 📌 작업 내용
무분별하게 큰 이미지 업로드가 올라가지 않도록 5MB 용량의 이미지 까지만 허용하도록 수정했습니다. 기존 default 크기로 1MB로 설정되어있으나 이는 너무 낮다고 판단되어 허용 크기를 늘리는 방향을 선택했습니다.

 또한 소셜로그인 이메일 중복 검사 기능이 없어 이전에 중복 가입이 된 것을 DB에서 확인했습니다. 따라서 중복검사 기능을 구현해 중복 가입이 되지 않도록 했습니다.


closes #87 
closes #99 
closes #101 