### PR TITLE
fix: 커뮤니티과 동행자 모집 게시글 조회수 증가 로직 DB 반영 안 되던 문제 수정 (#106)

### DIFF
--- a/src/main/java/com/project/Journey/community/service/CommunityService.java
+++ b/src/main/java/com/project/Journey/community/service/CommunityService.java
@@ -91,6 +91,7 @@ public class CommunityService {
     }
 
     //특정 게시글 조회
+    @Transactional
     public CommunityResponseDTO getPostByCommunityPostId(Long communitypostid, Long currentMemberId) {
         Community community = communityRepository.findById(communitypostid)
                 .orElseThrow(() -> new EntityNotFoundException("게시글을 찾을 수 없습니다."));

--- a/src/main/java/com/project/Journey/companion/service/PostService.java
+++ b/src/main/java/com/project/Journey/companion/service/PostService.java
@@ -217,23 +217,16 @@ public class PostService {
     }
 
     //조회 수가 높은 순서대로 조회(핫 게시글)
+    @Transactional
     public PostResponseDTO getPostByIdAndIncrementView(Long postId, Long currentUserId) {
-
-        String key = VIEW_COUNT_KEY + postId;
-        Long cnt = redisTemplate.opsForValue().increment(key, 1);
-
-        // Redis 첫 저장이면 DB 값으로 초기화
-        if (cnt != null && cnt == 1L) {
-            Post tmp = postRepository.findById(postId)
-                    .orElseThrow(() -> new IllegalArgumentException("게시글 없음"));
-            redisTemplate.opsForValue().set(key, tmp.getView_count() + 1);
-        }
-
         Post post = postRepository.findById(postId)
                 .orElseThrow(() -> new IllegalArgumentException("게시글 없음"));
-        return toDto(post, currentUserId);              // ★ isMine 적용
-    }
 
+        post.setView_count(post.getView_count() + 1);  // 바로 증가
+        // save 생략해도 트랜잭션 끝나면 dirty checking 으로 반영됨
+
+        return toDto(post, currentUserId);  // isMine 포함된 DTO 반환
+    }
 
 
 


### PR DESCRIPTION
## 📌 개요
커뮤니티 및 동행자 게시판의 조회수 증가 로직이 DB에 반영되지 않던 문제를 수정했습니다.

## 🤔 문제 요약
### 🔹 커뮤니티 게시판
- getPostByCommunityPostId()에서 community.setViewCount(...)로 값은 증가하지만
- @Transactional이 없어 DB에 반영되지 않음

### 🔹 동행자 게시판
- Redis에서 view count를 누적 후 DB에 반영하는 @Scheduled 방식 사용 중
- 하지만 PostRepository.incrementViewCount()가 누적값으로 덮어쓰는 방식이 아니어서
정상적으로 누적되지 않음

## 🛠 해결 방법
### ✅ 커뮤니티 게시판
- getPostByCommunityPostId()에 @Transactional(readOnly = false) 어노테이션 추가
- JPA 영속성 컨텍스트로 인해 viewCount++가 DB에 자동 반영되도록 수정

### ✅ 동행자 게시판
- Redis → DB 동기화 메서드 syncViewCountToDatabase() 수정

## ✅ 작업 내역
 - [x] 커뮤니티 게시판 조회수 증가 시 DB 반영되도록 트랜잭션 적용
 - [x] 동행자 게시판 조회수 동기화 시 누적 반영되도록 로직 수정
 - [x] 새로고침/상세 페이지 접근 시 프론트 및 DB에서 조회수 정상 확인
 - [x] 기존 커뮤니티/동행자 게시글 수정 및 조회 API 영향도 확인

## 🔗 관련 이슈
- Closes #106
