### PR TITLE
feat: 프로필 이미지 업로드 기능 추가 (#58)

### DIFF
--- a/src/main/java/com/project/Journey/login/member/controller/ProfileController.java
+++ b/src/main/java/com/project/Journey/login/member/controller/ProfileController.java
@@ -13,6 +13,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 
@@ -96,4 +97,12 @@ public class ProfileController {
         return ResponseEntity.ok(profileService.getProfileImage(id));
     }
 
+    @Operation(summary = "프로필 이미지 업로드")
+    @ApiResponse(responseCode = "200", description = "업로드 성공")
+    @PostMapping("/{id}/profile-image")
+    public ResponseEntity<?> uploadProfileImage(@PathVariable Long id,
+                                                @RequestParam("image") MultipartFile file) {
+        profileService.updateProfileImage(id, file);
+        return ResponseEntity.ok("프로필 이미지 업로드 완료");
+    }
 }

--- a/src/main/java/com/project/Journey/login/member/domain/Member.java
+++ b/src/main/java/com/project/Journey/login/member/domain/Member.java
@@ -118,4 +118,12 @@ public class Member {
         if(homepage != null) this.homepage = homepage;
         if(bio != null) this.bio = bio;
     }
+
+    public void setProfileImage(String profileImage) {
+        this.profileImage = profileImage;
+    }
+
+    public void updateProfileImage(String imageUrl) {
+        this.profileImage = imageUrl;
+    }
 }

--- a/src/main/java/com/project/Journey/login/member/service/ProfileService.java
+++ b/src/main/java/com/project/Journey/login/member/service/ProfileService.java
@@ -1,5 +1,6 @@
 package com.project.Journey.login.member.service;
 
+import com.project.Journey.awss3.S3Service;
 import com.project.Journey.login.member.domain.Member;
 import com.project.Journey.login.member.domain.MemberTag;
 import com.project.Journey.login.member.dto.ProfileImageResponseDTO;
@@ -8,9 +9,11 @@ import com.project.Journey.login.member.dto.ProfileUpdateRequestDTO;
 import com.project.Journey.login.member.repository.MemberRepository;
 import com.project.Journey.login.member.repository.MemberTagRepository;
 
+import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
 @Service @RequiredArgsConstructor
 @Transactional
@@ -18,6 +21,7 @@ public class ProfileService {
 
     private final MemberRepository memberRepo;
     private final MemberTagRepository tagRepo;
+    private final S3Service s3Service;
 
     @Transactional(readOnly = true)
     public ProfileResponseDTO getMyProfile(Long memberId) {
@@ -77,6 +81,21 @@ public class ProfileService {
                 .nickname(member.getDisplayName())
                 .profileImage(member.getProfileImage())
                 .build();
+    }
+
+
+    @Transactional
+    public void updateProfileImage(Long memberId, MultipartFile file) {
+        Member member = memberRepo.findById(memberId)
+                .orElseThrow(() -> new EntityNotFoundException("회원 없음"));
+
+        // 기존 이미지 삭제 (선택)
+        if (member.getProfileImage() != null) {
+            s3Service.deleteS3Image(member.getProfileImage());
+        }
+
+        String imageUrl = s3Service.uploadProfileImage(file, member.getRole());
+        member.setProfileImage(imageUrl);
     }
 
 }


### PR DESCRIPTION
## 📌 주요 변경 사항

사용자의 프로필 이미지를 등록하거나 수정할 수 있는 API를 추가했습니다.

### ✅ 구현 내용
- `POST /api/members/{id}/profile-image` API 추가 (`ProfileController`)
  - `MultipartFile` 형식의 이미지를 업로드 받아 S3에 저장
  - S3 업로드 완료 후 해당 이미지 URL을 `Member.profileImage` 필드에 저장
  - 기존 프로필 이미지가 존재할 경우 S3에서 삭제 처리

- `ProfileService`에 이미지 업로드 로직 추가
  - `MemberRepository`를 통해 회원 조회 및 수정
  - `S3Service`의 `uploadProfileImage`, `deleteS3Image` 메서드 재사용

---

## 📷 예시 요청

```http
POST /api/members/1/profile-image
Content-Type: multipart/form-data
