### PR TITLE
feat: 프로필 수정/업로드 시 최신 정보 DTO 반환 및 세션 동기화

### DIFF
--- a/src/main/java/com/project/Journey/login/auth/CustomUserDetails.java
+++ b/src/main/java/com/project/Journey/login/auth/CustomUserDetails.java
@@ -16,6 +16,12 @@ import java.util.Collections;
 public class CustomUserDetails implements UserDetails {
 
     private final Member member; // 연관된 Member 엔티티
+    public Long getId() {
+        return member.getId();
+    };
+    public Member getMember() {
+        return member;
+    };
 
     public CustomUserDetails(Member member) {
         this.member = member;
@@ -58,4 +64,10 @@ public class CustomUserDetails implements UserDetails {
     public boolean isEnabled() {
         return true; // 계정 활성화 여부
     }
+
+    public void refreshFrom(Member src) {
+        this.member.copyProfileFrom(src);
+    }
+
+
 }

--- a/src/main/java/com/project/Journey/login/member/controller/ProfileController.java
+++ b/src/main/java/com/project/Journey/login/member/controller/ProfileController.java
@@ -35,19 +35,12 @@ public class ProfileController {
     }
 
     @Operation(summary = "내 프로필 수정",
-            description = """
-               전달한 필드만 업데이트합니다.  
-               · tags : 최대 3개, 각 6자 ≤  
-               """)
-    @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "수정 완료"),
-            @ApiResponse(responseCode = "400", description = "검증 실패 (태그 3개 초과, 6자 초과 등)")
-    })
+            description = "전달된 필드만 업데이트합니다.<br>· tags: 최대 3개, 각 6자 이하")
     @PatchMapping("/{id}/profile")
-    public ResponseEntity<?> updateProfile(@PathVariable Long id,
-                                           @Valid @RequestBody ProfileUpdateRequestDTO dto) {
-        profileService.updateProfile(id, dto);
-        return ResponseEntity.ok("프로필 수정 완료");
+    public ResponseEntity<ProfileResponseDTO> updateProfile(
+            @PathVariable("id") Long id,
+            @Valid @RequestBody ProfileUpdateRequestDTO dto) {
+        return ResponseEntity.ok(profileService.updateProfile(id, dto));
     }
 
     @Operation(summary = "여행 일정 추가")
@@ -82,27 +75,22 @@ public class ProfileController {
         return ResponseEntity.ok("삭제 완료");
     }
 
-    @Operation(
-            summary = "프로필 이미지와 닉네임 조회",
-            description = "댓글, 목록 그리고 헤더에 사용할 가벼운 전용 API입니다."
-    )
-    @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "조회 성공",
-                    content = @Content(schema = @Schema(implementation = ProfileImageResponseDTO.class))),
-            @ApiResponse(responseCode = "400", description = "회원 없음",
-                    content = @Content(schema = @Schema(example = "회원 없음")))
-    })
+    @Operation(summary = "프로필 이미지와 닉네임 조회",
+            description = "댓글, 목록, 헤더 등에서 사용할 가벼운 전용 API")
     @GetMapping("/{id}/profile-image")
-    public ResponseEntity<ProfileImageResponseDTO> getProfileImage(@PathVariable Long id) {
-        return ResponseEntity.ok(profileService.getProfileImage(id));
+    public ProfileImageResponseDTO getProfileImage(@PathVariable Long id) {
+        return profileService.getProfileImage(id);
     }
 
     @Operation(summary = "프로필 이미지 업로드")
-    @ApiResponse(responseCode = "200", description = "업로드 성공")
-    @PostMapping("/{id}/profile-image")
-    public ResponseEntity<?> uploadProfileImage(@PathVariable Long id,
-                                                @RequestParam("image") MultipartFile file) {
-        profileService.updateProfileImage(id, file);
-        return ResponseEntity.ok("프로필 이미지 업로드 완료");
+    @PostMapping(
+            path = "/{id}/profile-image",
+            consumes = "multipart/form-data")
+    public ResponseEntity<ProfileImageResponseDTO> uploadProfileImage(
+            @PathVariable Long id,
+            @RequestParam("image") MultipartFile file) {
+
+        ProfileImageResponseDTO res = profileService.updateProfileImage(id, file);
+        return ResponseEntity.ok(res);           // 최신 URL 즉시 반환
     }
 }

--- a/src/main/java/com/project/Journey/login/member/domain/Member.java
+++ b/src/main/java/com/project/Journey/login/member/domain/Member.java
@@ -126,4 +126,14 @@ public class Member {
     public void updateProfileImage(String imageUrl) {
         this.profileImage = imageUrl;
     }
+
+    public void copyProfileFrom(Member src) {
+        this.nickname     = src.nickname;
+        this.age          = src.age;
+        this.gender       = src.gender;
+        this.region       = src.region;
+        this.homepage     = src.homepage;
+        this.bio          = src.bio;
+        this.profileImage = src.profileImage;
+    }
 }

--- a/src/main/java/com/project/Journey/login/member/service/ProfileService.java
+++ b/src/main/java/com/project/Journey/login/member/service/ProfileService.java
@@ -1,6 +1,7 @@
 package com.project.Journey.login.member.service;
 
 import com.project.Journey.awss3.S3Service;
+import com.project.Journey.login.auth.CustomUserDetails;
 import com.project.Journey.login.member.domain.Member;
 import com.project.Journey.login.member.domain.MemberTag;
 import com.project.Journey.login.member.dto.ProfileImageResponseDTO;
@@ -11,6 +12,8 @@ import com.project.Journey.login.member.repository.MemberTagRepository;
 
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -45,32 +48,40 @@ public class ProfileService {
 
     }
 
-    public void updateProfile(Long memberId, ProfileUpdateRequestDTO dto) {
+    @Transactional
+    public ProfileResponseDTO updateProfile(Long memberId,
+                                            ProfileUpdateRequestDTO dto) {
+
         Member m = memberRepo.findById(memberId)
                 .orElseThrow(() -> new IllegalArgumentException("회원 없음"));
 
-        m.updateProfile(
-                dto.getNickname(),
-                dto.getAge(),
-                dto.getGender(),
-                dto.getRegion(),
-                dto.getHomepage(),
-                dto.getBio()
-        );
+        m.updateProfile(dto.getNickname(), dto.getAge(), dto.getGender(),
+                dto.getRegion(), dto.getHomepage(), dto.getBio());
 
         tagRepo.deleteByMember(m);
         if (dto.getTags() != null && !dto.getTags().isEmpty()) {
-
             if (dto.getTags().size() > 3)
                 throw new IllegalArgumentException("태그는 최대 3개까지 가능합니다");
+            dto.getTags().forEach(tag -> tagRepo.save(new MemberTag(m, tag)));
+        }
 
-            dto.getTags().forEach(t -> {
-                if (t.length() > 6)
-                    throw new IllegalArgumentException("태그 '" + t + "' 는 6자를 초과합니다");
-                tagRepo.save(new MemberTag(m, t));
-            });
+        /* 3) (선택) 세션 principal 최신화 */
+        syncPrincipalIfPresent(memberId, m);   // 아래 유틸 참고
+
+        /* 4) 최신 DTO 반환 */
+        return toProfileDTO(m);
+    }
+
+    private void syncPrincipalIfPresent(Long memberId, Member updated) {
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        if (auth != null && auth.isAuthenticated()
+                && auth.getPrincipal() instanceof CustomUserDetails cud
+                && cud.getId().equals(memberId)) {
+
+            cud.refreshFrom(updated);   // CustomUserDetails 에 구현
         }
     }
+
 
     public ProfileImageResponseDTO getProfileImage(Long memberId) {
         Member member = memberRepo.findById(memberId)
@@ -85,17 +96,44 @@ public class ProfileService {
 
 
     @Transactional
-    public void updateProfileImage(Long memberId, MultipartFile file) {
+    public ProfileImageResponseDTO updateProfileImage(Long memberId,
+                                                      MultipartFile file) {
+
         Member member = memberRepo.findById(memberId)
                 .orElseThrow(() -> new EntityNotFoundException("회원 없음"));
 
-        // 기존 이미지 삭제 (선택)
-        if (member.getProfileImage() != null) {
+        if (member.getProfileImage() != null)
             s3Service.deleteS3Image(member.getProfileImage());
-        }
 
         String imageUrl = s3Service.uploadProfileImage(file, member.getRole());
         member.setProfileImage(imageUrl);
+
+        /* 세션 principal 최신화 */
+        syncPrincipalIfPresent(memberId, member);
+
+        return ProfileImageResponseDTO.builder()
+                .memberId(member.getId())
+                .nickname(member.getDisplayName())
+                .profileImage(member.getProfileImage())
+                .build();
+    }
+
+    private ProfileResponseDTO toProfileDTO(Member m) {
+        return ProfileResponseDTO.builder()
+                .memberId(m.getId())
+                .loginId(m.getLoginId())
+                .nickname(m.getNickname())
+                .age(m.getAge())
+                .gender(m.getGender())
+                .region(m.getRegion())
+                .homepage(m.getHomepage())
+                .bio(m.getBio())
+                .profileImage(m.getProfileImage())
+                .tags(tagRepo.findByMember(m)
+                        .stream()
+                        .map(MemberTag::getTag)
+                        .toList())
+                .build();
     }
 
 }


### PR DESCRIPTION
### 📌 작업 개요
프로필 수정(PATCH) 또는 이미지 업로드(POST) 후 프론트에서 추가 fetch 없이 최신 데이터를 바로 사용할 수 있도록,
서버에서 최신 DTO를 응답하고 세션 principal도 동기화하도록 개선했습니다.


### ✅ 주요 변경 사항
- `ProfileService.updateProfile()`, `updateProfileImage()`에서 최신 DTO 반환
- `CustomUserDetails.refreshFrom(Member)` 메서드 추가
- `Member` 엔티티에 `copyProfileFrom(Member)` 메서드 도입
- 세션 principal을 자동으로 동기화하는 유틸 메서드 `syncPrincipalIfPresent()` 도입
- `ProfileController`에서 PathVariable 이름 일관화 (`memberId` → `id`)
- Swagger 어노테이션 보강 및 multipart/form-data 명시

### ✅ 기대 효과
- 프론트에서 PATCH/POST 응답을 그대로 Pinia에 반영 가능
- 불필요한 `GET /members/me` 재호출 제거 → UX 개선 + 서버 부하 감소
- 댓글, 헤더 등에서 즉시 프로필 반영되어 일관성 유지


